### PR TITLE
Vise riktig navn på samtykke modal steg 9.

### DIFF
--- a/web/src/frontend/src/digisos/skjema/oppsummering/samtykkeInfoModal.tsx
+++ b/web/src/frontend/src/digisos/skjema/oppsummering/samtykkeInfoModal.tsx
@@ -60,7 +60,7 @@ class SamtykkeInfoModal extends React.Component<Props, {}> {
 		const bydelId: string = (bydel && bydel.lagret && bydel.lagret.value) || "";
 		let bydelsNavn = getBydel(kommuneId, bydelId, this.props.navEnheter);
 
-		if (bydelsNavn === "") {
+		if (bydelsNavn === null || bydelsNavn === "") {
 			bydelsNavn = kommuneNavn;
 		}
 		return { kommuneNavn, navKontorNavn: bydelsNavn };


### PR DESCRIPTION
I modalen vises nå teksten for eksempel:

 …kan oversendes til Horten kommune ved NAV Horten.
 …kan oversendes til Oslo kommune ved NAV Frogner.
 …kan oversendes til Bergen kommune ved NAV Bergenhus.
