### PR TITLE
Fjern brukerprofil-URL fra mock-config

### DIFF
--- a/scripts/mock_data/miljovariabler.json
+++ b/scripts/mock_data/miljovariabler.json
@@ -3,7 +3,6 @@
 	"soknadtilleggsstonader.url": "http://127.0.0.1:8186/soknadtilleggsstonader/app",
 	"dineutbetalinger.link.url": "http://www.nav.no/dineutbetalinger",
 	"dialogarena.navnolink.url": "http://127.0.0.1:/site/2",
-	"soknad.brukerprofil.url": "https://www.nav.no/person/personopplysninger",
 	"soknad.ettersending.antalldager": "42",
 	"soknad.alderspensjon.url": "https://tjenester.nav.no/pselv/tilleggsfunksjonalitet/innlogging.jsf",
 	"soknad.reelarbeidsoker.url": "https://tjenester.nav.no/sbl/arbeid/registering",


### PR DESCRIPTION
Fjerner brukerprofil-URL fra mock, da denne fjernes fra `/miljovariabler`-endepunktet, ref. navikt/sosialhjelp-soknad-api#185.