### PR TITLE
Bruker nytt /navenhet-endepunkt for å hente ut kun valgt navkontor.

### DIFF
--- a/src/digisos/data/kommuner.ts
+++ b/src/digisos/data/kommuner.ts
@@ -1,17 +1,17 @@
 import {Soknadsdata} from "../redux/soknadsdata/soknadsdataReducer";
 import {NavEnhet} from "../skjema/personopplysninger/adresse/AdresseTypes";
 
-function finnSoknadsMottaker(soknadsdata: Soknadsdata): NavEnhet | undefined {
-	let valgtNavEnhet: NavEnhet | undefined = undefined;
+function finnSoknadsMottaker(soknadsdata: Soknadsdata): NavEnhet | null {
+	let valgtNavEnhet: NavEnhet | null = null;
 	if (soknadsdata.personalia.navEnheter){
-		valgtNavEnhet = soknadsdata.personalia.navEnheter.find((navenhet: NavEnhet) => navenhet.valgt);
+		valgtNavEnhet = soknadsdata.personalia.navEnhet
 	}
 	return valgtNavEnhet;
 }
 
 function finnValgtEnhetsNavn(soknadsdata: Soknadsdata): string {
 	const soknadsmottaker = finnSoknadsMottaker(soknadsdata);
-	if (typeof soknadsmottaker !== 'undefined') {
+	if (soknadsmottaker !== null) {
 		return soknadsmottaker.enhetsnavn + ", " + soknadsmottaker.kommunenavn + " kommune";
 	}
 	return "";

--- a/src/digisos/redux/soknadsdata/soknadsdataContainerUtils.ts
+++ b/src/digisos/redux/soknadsdata/soknadsdataContainerUtils.ts
@@ -29,7 +29,7 @@ export interface SoknadsdataContainerProps {
     // Funksjoner:
     hentSoknadsdata: (brukerBehandlingId: string, urlPath: string) => void;
     lagreSoknadsdata: (brukerBehandlingId: string, urlPath: string, soknadsdata: any, responseHandler?: (response: any) => void) => void;
-    oppdaterSoknadsdataSti: (sti: string, soknadsdata: SoknadsdataType) => void;
+    oppdaterSoknadsdataSti: (sti: string, soknadsdata: SoknadsdataType | null) => void;
     settRestStatus: (sti: string, restStatus: REST_STATUS) => void;
     visSamtykkeInfo: (vis: boolean) => void;
     setValideringsfeil: (feilkode: ValideringsFeilKode, faktumKey: string) => void;

--- a/src/digisos/redux/soknadsdata/soknadsdataReducer.ts
+++ b/src/digisos/redux/soknadsdata/soknadsdataReducer.ts
@@ -81,6 +81,7 @@ export enum SoknadsSti {
 	BARNEUTGIFTER = "utgifter/barneutgifter",
 	ADRESSER = "personalia/adresser",
 	NAV_ENHETER = "personalia/navEnheter",
+	VALGT_NAV_ENHET = "personalia/navEnhet",
 	SIVILSTATUS = "familie/sivilstatus",
 	BASIS_PERSONALIA = "personalia/basisPersonalia",
 	FORSORGERPLIKT = "familie/forsorgerplikt",
@@ -113,6 +114,7 @@ export interface Personalia {
 	telefonnummer: Telefonnummer;
 	adresser: Adresser;
 	navEnheter: NavEnhet[];
+	navEnhet: null | NavEnhet;
 	basisPersonalia: BasisPersonalia;
 }
 
@@ -127,6 +129,7 @@ export const initialPersonaliaState: Personalia = {
 	telefonnummer: initialTelefonnummerState,
 	adresser: initialAdresserState,
 	navEnheter: [],
+	navEnhet: null,
 	basisPersonalia: initialBasisPersonalia
 };
 
@@ -181,7 +184,8 @@ export type SoknadsdataType
 	| Utgifter
 	| Adresser
 	| AdresseValg
-	| NavEnhet[];
+	| NavEnhet[]
+	| NavEnhet;
 
 interface SoknadsdataActionType {
 	type: SoknadsdataActionTypeKeys,
@@ -196,7 +200,8 @@ const initialSoknadsdataRestStatus = {
 		kontonummer: REST_STATUS.INITIALISERT,
 		basisPersonalia: REST_STATUS.INITIALISERT,
 		adresser: REST_STATUS.INITIALISERT,
-		navEnheter: REST_STATUS.INITIALISERT
+		navEnheter: REST_STATUS.INITIALISERT,
+		valgtNavEnhet: REST_STATUS.INITIALISERT
 	},
 	familie: {
 		sivilstatus: REST_STATUS.INITIALISERT,

--- a/src/digisos/skjema/personopplysninger/adresse/AdresseTypes.ts
+++ b/src/digisos/skjema/personopplysninger/adresse/AdresseTypes.ts
@@ -13,9 +13,10 @@ export interface AdressesokTreff {
 }
 
 export interface NavEnhet {
-	orgnr: string;
-	enhetsnr: string;
+	orgnr: null | string;
+	enhetsnr: null | string;
 	isMottakMidlertidigDeaktivert: boolean;
+	isMottakDeaktivert: boolean;
 	enhetsnavn: string;
 	kommunenavn: string;
 	kommuneNr: string;

--- a/src/digisos/skjema/personopplysninger/adresse/AdresseUtils.ts
+++ b/src/digisos/skjema/personopplysninger/adresse/AdresseUtils.ts
@@ -1,4 +1,4 @@
-import {AdresseKategori, AdressesokTreff, Gateadresse, NavEnhet, SoknadsMottakerStatus} from "./AdresseTypes";
+import {AdresseKategori, AdressesokTreff, Gateadresse, SoknadsMottakerStatus} from "./AdresseTypes";
 import {Soknadsdata} from "../../../redux/soknadsdata/soknadsdataReducer";
 import {REST_STATUS} from "../../../redux/soknad/soknadTypes";
 
@@ -20,14 +20,14 @@ const formaterAdresseString = (adresse: AdressesokTreff) => {
                 returverdi += " " + adresse.husnummer + husbokstav + ", " + adresse.postnummer + " " + adresse.poststed;
             } else {
                 if (adresse.postnummer !== null && adresse.poststed !== null) {
-                    returverdi += " , " + adresse.postnummer + " " + adresse.poststed;
+                    returverdi += ", " + adresse.postnummer + " " + adresse.poststed;
                 }
             }
         } else if (adresse.kommunenavn != null) {
             if (adresse.husnummer !== "" && adresse.husnummer !== null) {
                 returverdi += " " + adresse.husnummer + husbokstav + ", " + adresse.kommunenavn;
             } else {
-                returverdi += " , " + adresse.kommunenavn;
+                returverdi += ", " + adresse.kommunenavn;
             }
         }
     } catch (error) {
@@ -40,8 +40,8 @@ const formaterSoknadsadresse = (soknadAdresse: Gateadresse | null) => {
     let formatertSoknadAdresse = "";
     if (soknadAdresse) {
         formatertSoknadAdresse =
-            (soknadAdresse.gatenavn ? soknadAdresse.gatenavn : "") + " " +
-            (soknadAdresse.husnummer ? soknadAdresse.husnummer : "") + " " +
+            (soknadAdresse.gatenavn ? soknadAdresse.gatenavn : "") +
+            (soknadAdresse.husnummer ? " " + soknadAdresse.husnummer : "") +
             (soknadAdresse.husbokstav ? soknadAdresse.husbokstav : "") + ", " +
             soknadAdresse.postnummer + " " + soknadAdresse.poststed;
         formatertSoknadAdresse.replace(/ /, " ");
@@ -97,15 +97,17 @@ const ekstraherHusnummerHusbokstav = (inntastetAdresse: string): any => {
 
 const soknadsmottakerStatus = (soknadsdata: Soknadsdata): SoknadsMottakerStatus => {
     const navEnheter = soknadsdata.personalia.navEnheter;
-    const valgtNavEnhet: NavEnhet | undefined = navEnheter.find((navEnhet: NavEnhet) => navEnhet.valgt);
+    const valgtNavEnhet = soknadsdata.personalia.navEnhet;
     const navEnheterRestStatus: REST_STATUS = soknadsdata.restStatus.personalia.navEnheter;
     const adresser = soknadsdata.personalia.adresser;
 
-
+    if (valgtNavEnhet && valgtNavEnhet.isMottakDeaktivert) {
+        return SoknadsMottakerStatus.UGYLDIG
+    }
     if (valgtNavEnhet && valgtNavEnhet.isMottakMidlertidigDeaktivert) {
         return SoknadsMottakerStatus.MOTTAK_ER_MIDLERTIDIG_DEAKTIVERT
     }
-    if (valgtNavEnhet && valgtNavEnhet.valgt && !valgtNavEnhet.isMottakMidlertidigDeaktivert) {
+    if (valgtNavEnhet && valgtNavEnhet.valgt) {
         return SoknadsMottakerStatus.GYLDIG;
     }
     if (adresser.valg) {

--- a/src/digisos/skjema/personopplysninger/adresse/SoknadsmottakerInfo.tsx
+++ b/src/digisos/skjema/personopplysninger/adresse/SoknadsmottakerInfo.tsx
@@ -6,7 +6,6 @@ import {
     SoknadsdataContainerProps
 } from "../../../redux/soknadsdata/soknadsdataContainerUtils";
 import {
-    NavEnhet,
     SoknadsMottakerStatus
 } from "./AdresseTypes";
 import {soknadsmottakerStatus} from "./AdresseUtils";
@@ -19,8 +18,7 @@ class SoknadsmottakerInfo extends React.Component<Props, {}> {
 
     render() {
         const {soknadsdata} = this.props;
-        const navEnheter = soknadsdata.personalia.navEnheter;
-        const valgtNavEnhet = navEnheter.find((navEnhet: NavEnhet) => navEnhet.valgt);
+        const valgtNavEnhet = soknadsdata.personalia.navEnhet;
         let enhetsnavn = "";
         let kommunenavn = "";
         if (valgtNavEnhet) {
@@ -50,7 +48,7 @@ class SoknadsmottakerInfo extends React.Component<Props, {}> {
             informasjonspanel = (
                 <AlertStripe type="advarsel">
                     <FormattedHTMLMessage
-                        id="adresse.alertstripe.advarsel.fixme"
+                        id="adresse.alertstripe.advarsel.utenurl"
                         values={
                             {
                                 kommuneNavn: kommunenavn
@@ -61,7 +59,13 @@ class SoknadsmottakerInfo extends React.Component<Props, {}> {
         } else if (mottakerStatus === SoknadsMottakerStatus.MOTTAK_ER_MIDLERTIDIG_DEAKTIVERT) {
             informasjonspanel = (
                 <AlertStripe type="feil">
-                    <FormattedHTMLMessage id="adresse.alertstripe.feil.fixme"/>
+                    <FormattedHTMLMessage
+                        id="adresse.alertstripe.feil.utenurl"
+                        values={
+                            {
+                                kommuneNavn: kommunenavn
+                            }}
+                    />
                 </AlertStripe>
             )
         } else if (erSynlig) {

--- a/src/digisos/skjema/personopplysninger/adresse/SoknadsmottakerVelger.tsx
+++ b/src/digisos/skjema/personopplysninger/adresse/SoknadsmottakerVelger.tsx
@@ -19,7 +19,7 @@ class SoknadsmottakerVelger extends React.Component<Props,{}> {
 
 	velgNavKontor(event: any) {
 		this.props.navEnheter.forEach((soknadsmottaker: NavEnhet) => {
-			if (event.target.value === soknadsmottaker.orgnr) {
+			if (event.target.value === soknadsmottaker.enhetsnavn) {
 				this.props.onVelgSoknadsmottaker(soknadsmottaker)
 			}
 		});
@@ -27,11 +27,11 @@ class SoknadsmottakerVelger extends React.Component<Props,{}> {
 
 	render() {
 		const {navEnheter, ikkeVisPanel, intl} = this.props;
-		let orgnr = "velg";
+		let enhetsnavn = "velg";
 		if (navEnheter) {
 			navEnheter.forEach((soknadsmottaker: NavEnhet) => {
-				if (soknadsmottaker.valgt) {
-					orgnr = soknadsmottaker.orgnr;
+				if (soknadsmottaker.valgt && soknadsmottaker.enhetsnavn) {
+					enhetsnavn = soknadsmottaker.enhetsnavn;
 				}
 			});
 		}
@@ -41,14 +41,14 @@ class SoknadsmottakerVelger extends React.Component<Props,{}> {
 				className="velgNavKontorDropDown"
 				label={this.props.label || ""}
 				onChange={(event: any) => this.velgNavKontor(event)}
-				value={orgnr}
+				value={enhetsnavn}
 			>
 				<option value="velg" key="velg" disabled={true}>
 					{getIntlTextOrKey(intl, "kontakt.system.oppholdsadresse.velgMottaker")}
 				</option>
 				{navEnheter.map((soknadsmottaker: NavEnhet, index: number) => {
 					return (
-						<option value={soknadsmottaker.orgnr} key={index}>
+						<option value={soknadsmottaker.enhetsnavn} key={index}>
 							{soknadsmottaker.enhetsnavn}
 						</option>
 					);

--- a/src/nav-soknad/containers/StegMedNavigasjon.tsx
+++ b/src/nav-soknad/containers/StegMedNavigasjon.tsx
@@ -11,13 +11,13 @@ import {
     SkjemaConfig,
     SkjemaSteg,
     SkjemaStegType,
-    SoknadState
-} from "../../digisos/redux/soknad/soknadTypes";
+    SoknadState} from "../../digisos/redux/soknad/soknadTypes";
 import {DispatchProps, ValideringsFeilKode} from "../../digisos/redux/reduxTypes";
 import {setVisBekreftMangler} from "../../digisos/redux/oppsummering/oppsummeringActions";
 import {getIntlTextOrKey, IntlProps, scrollToTop} from "../utils";
 import {
-    avbrytSoknad, resetSendSoknadServiceUnavailable,
+    avbrytSoknad,
+    resetSendSoknadServiceUnavailable,
     sendSoknad
 } from "../../digisos/redux/soknad/soknadActions";
 import {gaTilbake, gaVidere, tilSteg} from "../../digisos/redux/navigasjon/navigasjonActions";
@@ -115,7 +115,7 @@ class StegMedNavigasjon extends React.Component<Props, {}> {
             const {feil} = this.props.validering;
 
             const valgtNavEnhet = this.finnSoknadsMottaker();
-            if (aktivtSteg.stegnummer === 1 && !valgtNavEnhet) {
+            if (erPaStegEnOgValgtNavEnhetErUgyldig(aktivtSteg.stegnummer, valgtNavEnhet)) {
                 this.props.dispatch(setValideringsfeil(ValideringsFeilKode.SOKNADSMOTTAKER_PAKREVD, "soknadsmottaker"));
                 this.props.dispatch(visValideringsfeilPanel());
             } else {
@@ -143,7 +143,7 @@ class StegMedNavigasjon extends React.Component<Props, {}> {
             }
 
             const {feil} = this.props.validering;
-            const valgtNavEnhet: NavEnhet | undefined = this.finnSoknadsMottaker();
+            const valgtNavEnhet = this.finnSoknadsMottaker();
 
             if (erPaStegEnOgValgtNavEnhetErUgyldig(aktivtSteg.stegnummer, valgtNavEnhet)) {
                 dispatch(setValideringsfeil(ValideringsFeilKode.SOKNADSMOTTAKER_PAKREVD, "soknadsmottaker"));
@@ -161,8 +161,16 @@ class StegMedNavigasjon extends React.Component<Props, {}> {
     }
 
     finnSoknadsMottaker() {
-        const valgtNavEnhet: NavEnhet | undefined = this.props.soknadsdata.personalia.navEnheter.find((navenhet: NavEnhet) => navenhet.valgt);
-        return valgtNavEnhet;
+        return this.props.soknadsdata.personalia.navEnhet as (NavEnhet | null);
+    }
+
+    finnKommunenavn() {
+        const valgtNavEnhet = this.props.soknadsdata.personalia.navEnhet as (NavEnhet | null);
+        debugger;
+        if (valgtNavEnhet === null) {
+            return "Din";
+        }
+        return valgtNavEnhet.kommunenavn;
     }
 
     handleGaTilbake(aktivtSteg: number) {
@@ -254,12 +262,24 @@ class StegMedNavigasjon extends React.Component<Props, {}> {
 
                         {soknad.visMidlertidigDeaktivertPanel && aktivtSteg !== 1 && (
                             <AlertStripe type="feil">
-                                <FormattedHTMLMessage id="adresse.alertstripe.feil.fixme"/>
+                                <FormattedHTMLMessage
+                                    id="adresse.alertstripe.feil.utenurl"
+                                    values={
+                                        {
+                                            kommuneNavn: this.finnKommunenavn()
+                                        }}
+                                />
                             </AlertStripe>
                         )}
                         {soknad.visIkkePakobletPanel && aktivtSteg !== 1 && (
                             <AlertStripe type="advarsel">
-                                <FormattedHTMLMessage id="adresse.alertstripe.advarsel.fixme"/>
+                                <FormattedHTMLMessage
+                                    id="adresse.alertstripe.advarsel.utenurl"
+                                    values={
+                                        {
+                                            kommuneNavn: this.finnKommunenavn()
+                                        }}
+                                />
                             </AlertStripe>
                         )}
 

--- a/src/nav-soknad/containers/StegMedNavigasjon.tsx
+++ b/src/nav-soknad/containers/StegMedNavigasjon.tsx
@@ -166,7 +166,6 @@ class StegMedNavigasjon extends React.Component<Props, {}> {
 
     finnKommunenavn() {
         const valgtNavEnhet = this.props.soknadsdata.personalia.navEnhet as (NavEnhet | null);
-        debugger;
         if (valgtNavEnhet === null) {
             return "Din";
         }

--- a/src/nav-soknad/containers/containerUtils.tsx
+++ b/src/nav-soknad/containers/containerUtils.tsx
@@ -24,7 +24,7 @@ export const valgtNavKontorErGyldigMenMottakErMidlertidigDeaktivert = (valgtNavK
 };
 
 export const responseIsOfTypeNavEnhet = (response: any) => {
-    if (response == undefined || typeof response === "string") {
+    if (response === null || response === undefined || typeof response === "string") {
         return false
     }
     const navEnhet: NavEnhet = response;

--- a/src/nav-soknad/containers/containerUtils.tsx
+++ b/src/nav-soknad/containers/containerUtils.tsx
@@ -2,7 +2,7 @@ import {NavEnhet} from "../../digisos/skjema/personopplysninger/adresse/AdresseT
 import {Dispatch} from "../../digisos/redux/reduxTypes";
 import {fetchToJson, HttpStatus} from "../utils/rest-utils";
 import {soknadsdataUrl} from "../../digisos/redux/soknadsdata/soknadsdataActions";
-import {SoknadsSti} from "../../digisos/redux/soknadsdata/soknadsdataReducer";
+import {oppdaterSoknadsdataSti, SoknadsSti} from "../../digisos/redux/soknadsdata/soknadsdataReducer";
 import {clearAllValideringsfeil} from "../../digisos/redux/validering/valideringActions";
 import {
     showServerFeil,
@@ -11,44 +11,44 @@ import {
 } from "../../digisos/redux/soknad/soknadActions";
 import {loggAdvarsel, loggFeil} from "../../digisos/redux/navlogger/navloggerActions";
 
-export const erPaStegEnOgValgtNavEnhetErUgyldig = (stegnummer: number, valgtNavEnhet: NavEnhet | undefined): boolean => {
-    return stegnummer === 1 && (!valgtNavEnhet || (valgtNavEnhet && valgtNavEnhet.isMottakMidlertidigDeaktivert) || (valgtNavEnhet && !valgtNavEnhet.enhetsnr))
+export const erPaStegEnOgValgtNavEnhetErUgyldig = (stegnummer: number, valgtNavEnhet: NavEnhet | null): boolean => {
+    return stegnummer === 1 && (!valgtNavEnhet || valgtNavEnhet.isMottakDeaktivert || valgtNavEnhet.isMottakMidlertidigDeaktivert);
 };
 
 export const valgtNavKontorErGyldig = (valgtNavKontor: NavEnhet | undefined): boolean => {
-    return valgtNavKontor && !valgtNavKontor.isMottakMidlertidigDeaktivert ? true : false;
+    return (valgtNavKontor !== undefined && !valgtNavKontor.isMottakDeaktivert && !valgtNavKontor.isMottakMidlertidigDeaktivert);
 };
 
 export const valgtNavKontorErGyldigMenMottakErMidlertidigDeaktivert = (valgtNavKontor: NavEnhet | undefined): boolean => {
-    return valgtNavKontor && valgtNavKontor.isMottakMidlertidigDeaktivert ? true : false
+    return (valgtNavKontor !== undefined && !valgtNavKontor.isMottakDeaktivert && valgtNavKontor.isMottakMidlertidigDeaktivert)
 };
 
-export const responseIsOfTypeListAndContainsAtleastOneObject = (response: any) => {
-    if(response && typeof response !== "string" && (response as NavEnhet[])[0]){
-        return true;
-    } else {
-        return false;
+export const responseIsOfTypeNavEnhet = (response: any) => {
+    if (response == undefined || typeof response === "string") {
+        return false
     }
+    const navEnhet: NavEnhet = response;
+    return  navEnhet.kommunenavn != null && navEnhet.kommuneNr != null
 };
 
-export const sjekkOmValgtNavEnhetErGyldig = (behandlingsId: string, dispatch: Dispatch, callbackHvisGyldig: () => void) => {
-    fetchToJson(soknadsdataUrl(behandlingsId, SoknadsSti.NAV_ENHETER)).then((response) => {
-        if (responseIsOfTypeListAndContainsAtleastOneObject(response)) {
-            const valgtNavKontor: NavEnhet | undefined = (response as NavEnhet[]).find((navEnhet: NavEnhet) => {
-                return navEnhet.valgt;
-            });
+export const sjekkOmValgtNavEnhetErGyldig = (behandlingsId: string, dispatch: Dispatch, callbackHvisGyldigEllerIkkeSatt: () => void) => {
+    fetchToJson(soknadsdataUrl(behandlingsId, SoknadsSti.VALGT_NAV_ENHET)).then((response) => {
+        if (responseIsOfTypeNavEnhet(response)) {
+            const valgtNavKontor: NavEnhet | undefined = response as NavEnhet;
+            dispatch(oppdaterSoknadsdataSti(SoknadsSti.VALGT_NAV_ENHET, valgtNavKontor));
 
             if (valgtNavKontorErGyldig(valgtNavKontor)) {
                 dispatch(clearAllValideringsfeil());
                 dispatch(visMidlertidigDeaktivertPanel(false));
                 dispatch(visIkkePakobletPanel(false));
-                callbackHvisGyldig();
+                callbackHvisGyldigEllerIkkeSatt();
             } else if (valgtNavKontorErGyldigMenMottakErMidlertidigDeaktivert(valgtNavKontor)) {
                 dispatch(visMidlertidigDeaktivertPanel(true));
             } else {
                 dispatch(visIkkePakobletPanel(true))
             }
         }
+        callbackHvisGyldigEllerIkkeSatt();
 
     }).catch((reason: any) => {
         if (reason.message === HttpStatus.UNAUTHORIZED) {

--- a/src/nav-soknad/containers/containerUtils.tsx
+++ b/src/nav-soknad/containers/containerUtils.tsx
@@ -47,8 +47,9 @@ export const sjekkOmValgtNavEnhetErGyldig = (behandlingsId: string, dispatch: Di
             } else {
                 dispatch(visIkkePakobletPanel(true))
             }
+        } else {
+            callbackHvisGyldigEllerIkkeSatt();
         }
-        callbackHvisGyldigEllerIkkeSatt();
 
     }).catch((reason: any) => {
         if (reason.message === HttpStatus.UNAUTHORIZED) {

--- a/src/nav-soknad/containers/containers.test.tsx
+++ b/src/nav-soknad/containers/containers.test.tsx
@@ -1,5 +1,5 @@
 import {
-    erPaStegEnOgValgtNavEnhetErUgyldig, responseIsOfTypeListAndContainsAtleastOneObject,
+    erPaStegEnOgValgtNavEnhetErUgyldig, responseIsOfTypeNavEnhet,
 } from "./containerUtils";
 import {NavEnhet} from "../../digisos/skjema/personopplysninger/adresse/AdresseTypes";
 
@@ -8,6 +8,7 @@ const enUgyldigNavEnhet: NavEnhet =
         orgnr: "1234",
         enhetsnr: "2345",
         isMottakMidlertidigDeaktivert: true,
+        isMottakDeaktivert: false,
         enhetsnavn: "asdf",
         kommunenavn: "fdsa",
         kommuneNr: "3456",
@@ -19,6 +20,7 @@ const enGyldigNavEnhet: NavEnhet =
         orgnr: "1234",
         enhetsnr: "2345",
         isMottakMidlertidigDeaktivert: false,
+        isMottakDeaktivert: false,
         enhetsnavn: "asdf",
         kommunenavn: "fdsa",
         kommuneNr: "3456",
@@ -30,6 +32,7 @@ const ugyldigNavenhetEnhetsnrNull: any =
         orgnr: "1234",
         enhetsnr: null,
         isMottakMidlertidigDeaktivert: false,
+        isMottakDeaktivert: true,
         enhetsnavn: "asdf",
         kommunenavn: "fdsa",
         kommuneNr: "3456",
@@ -37,8 +40,8 @@ const ugyldigNavenhetEnhetsnrNull: any =
     };
 
 test("that erPaStegEnOgValgtNavEnhetErUgyldig gir riktig svar", () => {
-    expect(erPaStegEnOgValgtNavEnhetErUgyldig(1, undefined)).toBe(true);
-    expect(erPaStegEnOgValgtNavEnhetErUgyldig(2, undefined)).toBe(false);
+    expect(erPaStegEnOgValgtNavEnhetErUgyldig(1, null)).toBe(true);
+    expect(erPaStegEnOgValgtNavEnhetErUgyldig(2, null)).toBe(false);
     expect(erPaStegEnOgValgtNavEnhetErUgyldig(1, enUgyldigNavEnhet)).toBe(true);
     expect(erPaStegEnOgValgtNavEnhetErUgyldig(2, enUgyldigNavEnhet)).toBe(false);
     expect(erPaStegEnOgValgtNavEnhetErUgyldig(1, enGyldigNavEnhet)).toBe(false);
@@ -50,18 +53,20 @@ const gyldigNavEnhet: NavEnhet = {
     orgnr: "12345",
     enhetsnr: "4321",
     isMottakMidlertidigDeaktivert: false,
+    isMottakDeaktivert: false,
     enhetsnavn: "Enhetsnavn",
     kommunenavn: "Kommunenavn",
     kommuneNr: "15533",
     valgt: true,
 };
 
-const undefinedNavEnhet: undefined = undefined;
+const undefinedNavEnhet: null = null;
 
 const navEnhetMidlertidigDeaktivert: NavEnhet = {
     orgnr: "12345",
     enhetsnr: "4321",
     isMottakMidlertidigDeaktivert: true,
+    isMottakDeaktivert: false,
     enhetsnavn: "Enhetsnavn",
     kommunenavn: "Kommunenavn",
     kommuneNr: "15533",
@@ -69,9 +74,10 @@ const navEnhetMidlertidigDeaktivert: NavEnhet = {
 };
 
 const navEnhetMedManglendeEnhetsnr: NavEnhet = {
-    orgnr: "12345",
-    enhetsnr: "4321",
+    orgnr: null,
+    enhetsnr: null,
     isMottakMidlertidigDeaktivert: true,
+    isMottakDeaktivert: true,
     enhetsnavn: "Enhetsnavn",
     kommunenavn: "Kommunenavn",
     kommuneNr: "15533",
@@ -95,15 +101,13 @@ const ugyldigResponseNull: null = null;
 const ugyldigResponseString: string = "En random string";
 const ugyldigResponseRandomObject = { "bare": "noe", "tull": "og", "tall": 1234556};
 const ugyldigResponseTomListe: any[] = [];
-const ugyldigResponseListeMedFeilTypeObjecter = [ugyldigResponseRandomObject];
-const gyldigResponse = [gyldigNavEnhet]
+const gyldigResponse = gyldigNavEnhet;
 
 test("that responseIsOfTypeListOfNavEnhetAndHasAtleastOneElement ikke fører til nullpointer feil", () => {
-    expect(responseIsOfTypeListAndContainsAtleastOneObject(ugyldigResponseUndefined)).toBe(false);
-    expect(responseIsOfTypeListAndContainsAtleastOneObject(ugyldigResponseNull)).toBe(false);
-    expect(responseIsOfTypeListAndContainsAtleastOneObject(ugyldigResponseString)).toBe(false);
-    expect(responseIsOfTypeListAndContainsAtleastOneObject(ugyldigResponseRandomObject)).toBe(false);
-    expect(responseIsOfTypeListAndContainsAtleastOneObject(ugyldigResponseTomListe)).toBe(false);
-    expect(responseIsOfTypeListAndContainsAtleastOneObject(ugyldigResponseListeMedFeilTypeObjecter)).toBe(true);
-    expect(responseIsOfTypeListAndContainsAtleastOneObject(gyldigResponse)).toBe(true)
+    expect(responseIsOfTypeNavEnhet(ugyldigResponseUndefined)).toBe(false);
+    expect(responseIsOfTypeNavEnhet(ugyldigResponseNull)).toBe(false);
+    expect(responseIsOfTypeNavEnhet(ugyldigResponseString)).toBe(false);
+    expect(responseIsOfTypeNavEnhet(ugyldigResponseRandomObject)).toBe(false);
+    expect(responseIsOfTypeNavEnhet(ugyldigResponseTomListe)).toBe(false);
+    expect(responseIsOfTypeNavEnhet(gyldigResponse)).toBe(true)
 });


### PR DESCRIPTION
* Bruker nytt /navenhet endepunkt for å hente ut kun valgt navkontor.
* Setter valgt=true selv om navkontor ikke er gyldig.
* Fjerner mellomrom ved formattering adresse i adressesøket.
* Legger på kommunenavn i alertStripe