### PR TITLE
Fjerne gul informasjonsbok på ettersendelsessiden når det er nedetid.

### DIFF
--- a/src/digisos/skjema/ettersendelse/index.tsx
+++ b/src/digisos/skjema/ettersendelse/index.tsx
@@ -197,7 +197,7 @@ class Ettersendelse extends React.Component<Props, OwnState> {
                         }
                     )}
 
-                    {opprettNyEttersendelseFeilet && (
+                    {opprettNyEttersendelseFeilet && !isNedetid &&  (
                         <AvsnittMedMarger className="ettersendelse__vedlegg__header">
                             <Informasjonspanel
                                 ikon={InformasjonspanelIkon.HENSYN}


### PR DESCRIPTION
(Da returnerer serveren 503, dette tolker frontend som at ettersendelsestiden er utgått. )