### PR TITLE
encodeURI brukes for å encode filnavn. Dette sørger for at æøå ikke f…

### DIFF
--- a/src/digisos/skjema/okonomiskeOpplysninger/LastOppFil.tsx
+++ b/src/digisos/skjema/okonomiskeOpplysninger/LastOppFil.tsx
@@ -35,8 +35,6 @@ class LastOppFil extends React.Component<Props, {}> {
 
             const fileName = files[0].name;
             const encoded = encodeURI(fileName);
-            console.log("Filename encoded: " + encoded);
-
             formData.append("file", files[0], encoded);
             this.props.dispatch(lastOppFil(opplysning, formData, behandlingsId));
             this.leggTilVedleggKnapp.value = "";

--- a/src/digisos/skjema/okonomiskeOpplysninger/LastOppFil.tsx
+++ b/src/digisos/skjema/okonomiskeOpplysninger/LastOppFil.tsx
@@ -32,7 +32,12 @@ class LastOppFil extends React.Component<Props, {}> {
                 return;
             }
             const formData = new FormData();
-            formData.append("file", files[0], files[0].name);
+
+            const fileName = files[0].name;
+            const encoded = encodeURI(fileName);
+            console.log("Filename encoded: " + encoded);
+
+            formData.append("file", files[0], encoded);
             this.props.dispatch(lastOppFil(opplysning, formData, behandlingsId));
             this.leggTilVedleggKnapp.value = "";
         }

--- a/src/digisos/skjema/okonomiskeOpplysninger/OpplastetVedlegg.tsx
+++ b/src/digisos/skjema/okonomiskeOpplysninger/OpplastetVedlegg.tsx
@@ -21,12 +21,12 @@ export default class OpplastetVedlegg extends React.Component<AllProps, {}> {
     render() {
         const {fil} = this.props;
         const lastNedUrl = `opplastetVedlegg/${fil.uuid}/fil`;
-
+        const filnavn = decodeURI(fil.filNavn);
         return (
             <div className="vedleggsliste__vedlegg">
                 <span className="vedleggsliste__filnavn">
                     <Lenkeknapp onClick={() => downloadAttachedFile(lastNedUrl)}>
-                        {fil.filNavn}
+                        {filnavn}
                     </Lenkeknapp>
                 </span>
                 <span className="vedleggsliste__slett_ikon">


### PR DESCRIPTION
…orsvinner i backend en plass.

decodeURI brukes for å decode filnavn.