### PR TITLE
Oppgraderer nav-frontend-veilederpanel-style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10695,9 +10695,9 @@
       "integrity": "sha512-A+xcmFMXtL9m7SHLnHIBcWzWmAm72z06RH0+/ImAsgDfdvnZNkyJOg+TNofCDF7+S4Y1fwnAEU9byxVXyLUV1Q=="
     },
     "nav-frontend-veilederpanel-style": {
-      "version": "0.0.25",
-      "resolved": "https://registry.npmjs.org/nav-frontend-veilederpanel-style/-/nav-frontend-veilederpanel-style-0.0.25.tgz",
-      "integrity": "sha512-W+zU1aAHxhPRPspLQfB1YLGPZ+oT47/qGKYApvgaslKQx4LROhOo9SxJEDWKTbU/BdsNLJqAVvWLiRzD44Hjpg=="
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/nav-frontend-veilederpanel-style/-/nav-frontend-veilederpanel-style-0.0.27.tgz",
+      "integrity": "sha512-Zr4D5KnvGsnW7cFGg5G/QNE8xGhtQMpgYzb8hK6IZNT6JwrInZkrR3ramufKD4AJNSBhIyXbaUWRFQX4tmdN8Q=="
     },
     "nearley": {
       "version": "2.19.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "nav-frontend-veileder": "^2.0.16",
     "nav-frontend-veileder-style": "^2.0.13",
     "nav-frontend-veilederpanel": "^0.1.24",
-    "nav-frontend-veilederpanel-style": "0.0.25",
+    "nav-frontend-veilederpanel-style": "0.0.27",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-autocomplete": "^1.8.1",


### PR DESCRIPTION
npm behandler alle 0.x versjoner som nye major versjoner, derfor ble ikke denne tatt med i tidligere runder med oppgraderinger. :) Virker også som om nav-frontend-moduler med jevne mellomrom bumper versjonsnr uten at det er noen reelle endringer i komponentet.