### PR TITLE
Feature/npm audit action

### DIFF
--- a/.github/workflows/npm_audit.yml
+++ b/.github/workflows/npm_audit.yml
@@ -26,4 +26,4 @@ jobs:
             - name: Install dependencies
               run: npm ci
             - name: Run npm audit
-              run: npm audit
+              run: npm audit --audit-level=moderate # Denne kan justeres hvis vi ønsker at bygg brekker på sårbarheter lavere enn moderate. Mulige verdier er low|moderate|high|critical

--- a/.github/workflows/npm_audit.yml
+++ b/.github/workflows/npm_audit.yml
@@ -1,0 +1,29 @@
+name: npm audit
+on:
+    push:
+        branches:
+            - "**" # Build all branches
+        tags-ignore:
+            - "**" # Don't build any tags
+
+env:
+    CI: true
+
+    jobs:
+        build:
+            name: Run npm audit
+            runs-on: ubuntu-latest
+            steps:
+                - uses: actions/setup-node@v1
+                with:
+                    node-version: '12.8.1'
+                - uses: actions/checkout@v1
+                - uses: actions/cache@v1.1.2
+                with:
+                    path: ~/.npm
+                    key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+                    restore-keys: ${{ runner.os }}-node-
+              - name: Install dependencies
+                run: npm ci
+              - name: Run npm audit
+                run: npm audit

--- a/.github/workflows/npm_audit.yml
+++ b/.github/workflows/npm_audit.yml
@@ -1,29 +1,29 @@
 name: npm audit
 on:
-  push:
-    branches:
-      - "**" # Build all branches
-    tags-ignore:
-      - "**" # Don't build any tags
+    push:
+        branches:
+            - "**" # Build all branches
+        tags-ignore:
+            - "**" # Don't build any tags
 
 env:
-   CI: true
+    CI: true
 
 jobs:
-  build:
-    name: Run npm audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '12.8.1'
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1.1.2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: ${{ runner.os }}-node-
-      - name: Install dependencies
-        run: npm ci
-      - name: Run npm audit
-        run: npm audit
+    build:
+        name: Run npm audit
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: "12.8.1"
+            - uses: actions/checkout@v1
+            - uses: actions/cache@v1.1.2
+              with:
+                  path: ~/.npm
+                  key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+                  restore-keys: ${{ runner.os }}-node-
+            - name: Install dependencies
+              run: npm ci
+            - name: Run npm audit
+              run: npm audit

--- a/.github/workflows/npm_audit.yml
+++ b/.github/workflows/npm_audit.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v1
-      with:
-        node-version: '12.8.1'
+        with:
+          node-version: '12.8.1'
       - uses: actions/checkout@v1
       - uses: actions/cache@v1.1.2
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-        restore-keys: ${{ runner.os }}-node-
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
       - name: Install dependencies
-      run: npm ci
+        run: npm ci
       - name: Run npm audit
-      run: npm audit
+        run: npm audit

--- a/.github/workflows/npm_audit.yml
+++ b/.github/workflows/npm_audit.yml
@@ -1,29 +1,29 @@
 name: npm audit
 on:
-    push:
-        branches:
-            - "**" # Build all branches
-        tags-ignore:
-            - "**" # Don't build any tags
+  push:
+    branches:
+      - "**" # Build all branches
+    tags-ignore:
+      - "**" # Don't build any tags
 
 env:
-    CI: true
+   CI: true
 
-    jobs:
-        build:
-            name: Run npm audit
-            runs-on: ubuntu-latest
-            steps:
-                - uses: actions/setup-node@v1
-                with:
-                    node-version: '12.8.1'
-                - uses: actions/checkout@v1
-                - uses: actions/cache@v1.1.2
-                with:
-                    path: ~/.npm
-                    key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-                    restore-keys: ${{ runner.os }}-node-
-              - name: Install dependencies
-                run: npm ci
-              - name: Run npm audit
-                run: npm audit
+jobs:
+  build:
+    name: Run npm audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v1
+      with:
+        node-version: '12.8.1'
+      - uses: actions/checkout@v1
+      - uses: actions/cache@v1.1.2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+        restore-keys: ${{ runner.os }}-node-
+      - name: Install dependencies
+      run: npm ci
+      - name: Run npm audit
+      run: npm audit


### PR DESCRIPTION
Egen action for `npm audit`. Dette er de sanne varslene som vi får ved kjøring av `npm install` lokalt, men med litt mer informasjon.

Det er ikke alle sårbarheter vi kan / trenger å patche med en gang, så det bør være mulig å flette PRer selv om denne actionen ikke passerer.