### PR TITLE
La "gå videre"-knapp vente på adressevalg-restkall.

### DIFF
--- a/src/nav-soknad/containers/StegMedNavigasjon.tsx
+++ b/src/nav-soknad/containers/StegMedNavigasjon.tsx
@@ -10,7 +10,7 @@ import Stegindikator from "nav-frontend-stegindikator/lib/stegindikator";
 
 import Feiloppsummering from "../components/validering/Feiloppsummering";
 import Knapperad from "../components/knapperad";
-import {SkjemaConfig, SkjemaSteg, SkjemaStegType} from "../../digisos/redux/soknad/soknadTypes";
+import {REST_STATUS, SkjemaConfig, SkjemaSteg, SkjemaStegType} from "../../digisos/redux/soknad/soknadTypes";
 import {ValideringsFeilKode} from "../../digisos/redux/reduxTypes";
 import {setVisBekreftMangler} from "../../digisos/redux/oppsummering/oppsummeringActions";
 import {getIntlTextOrKey, scrollToTop} from "../utils";
@@ -66,6 +66,9 @@ const StegMedNavigasjon = (
     const nedetidstart = soknad.nedetid ? soknad.nedetid.nedetidStartText : "";
     const nedetidslutt = soknad.nedetid ? soknad.nedetid.nedetidSluttText : "";
     const isNedetid = soknad.nedetid ? soknad.nedetid.isNedetid : false;
+    const adresseValgRestStatus = soknadsdata.restStatus.personalia.adresser;
+    const isAdresseValgRestPending =
+        adresseValgRestStatus === REST_STATUS.INITIALISERT || adresseValgRestStatus === REST_STATUS.PENDING;
 
     const loggAdresseTypeTilGrafana = () => {
         const adresseTypeValg = soknadsdata.personalia.adresser.valg;
@@ -143,7 +146,7 @@ const StegMedNavigasjon = (
         }
     };
 
-    const nextButtonPending = soknad.sendSoknadPending;
+    const nextButtonPending = soknad.sendSoknadPending || isAdresseValgRestPending;
     const {skjemaConfig, stegKey, ikon, children} = props;
 
     const {feil, visValideringsfeil} = validering;


### PR DESCRIPTION
Slik at når bruker velger en adressetype så vil "Gå videre"-knappen bli grå med spinner og man kan ikke trykke på den.
Når adresevalget er lastet inn blir den blå igjen.
Dette fordi det er en irriterende state der man har trykket på adressevalg, men er for rask til å trykke på Gå videre, så blir kan ikke kvitt feilmeldingene og navenheten blir på en måte aldri valgt