### PR TITLE
Feature/ny ingress dev nav no

### DIFF
--- a/nais/dev/q0.json
+++ b/nais/dev/q0.json
@@ -2,9 +2,8 @@
   "applicationName": "sosialhjelp-soknad",
   "namespace": "q0",
   "ingresses": [
-    "https://sosialhjelp-soknad-q0.nais.oera-q.local/",
     "https://sosialhjelp-soknad-q0.dev-sbs.nais.io/",
-    "https://tjenester-q0.nav.no/sosialhjelp-soknad",
+    "https://www-q0.dev.nav.no/sosialhjelp/soknad",
     "https://www-q0.nav.no/sosialhjelp/soknad"
   ],
   "prometheusEnabled": true,

--- a/nais/dev/q1.json
+++ b/nais/dev/q1.json
@@ -2,9 +2,8 @@
   "applicationName": "sosialhjelp-soknad",
   "namespace": "q1",
   "ingresses": [
-    "https://sosialhjelp-soknad-q1.nais.oera-q.local/",
     "https://sosialhjelp-soknad-q1.dev-sbs.nais.io/",
-    "https://tjenester-q1.nav.no/sosialhjelp-soknad",
+    "https://www-q1.dev.nav.no/sosialhjelp/soknad",
     "https://www-q1.nav.no/sosialhjelp/soknad"
   ],
   "prometheusEnabled": true,

--- a/src/nav-soknad/utils/index.ts
+++ b/src/nav-soknad/utils/index.ts
@@ -18,7 +18,7 @@ export function erMockMiljoEllerDev(): boolean {
     return (
         url.indexOf("sosialhjelp-test.dev-sbs.nais.io") > 0 ||
         url.indexOf("soknadsosialhjelp-t1.nais.oera") > 0 ||
-        url.indexOf(".dev.nav.no") > 0 ||
+        url.indexOf("sosialhjelp-soknad.dev.nav.no") > 0 || // Fanger ikke opp www-q*.dev.nav.no
         url.indexOf(".labs.nais.io") > 0 || // Fanger også digisos.labs.nais.io
         url.indexOf("digisos-test.com") > 0
     );

--- a/src/nav-soknad/utils/rest-utils.ts
+++ b/src/nav-soknad/utils/rest-utils.ts
@@ -47,7 +47,10 @@ export function getApiBaseUrl(withAccessToken?: boolean): string {
     if (window.location.origin.indexOf("nais.oera") >= 0) {
         return window.location.origin.replace(`${CONTEXT_PATH}`, `${API_CONTEXT_PATH}`) + `/${apiContextPath}/`;
     }
-    if (window.location.origin.indexOf("dev.nav.no") >= 0 || window.location.origin.indexOf("labs.nais.io") >= 0) {
+    if (
+        window.location.origin.indexOf("sosialhjelp-soknad.dev.nav.no") >= 0 ||
+        window.location.origin.indexOf("labs.nais.io") >= 0
+    ) {
         if (window.location.origin.indexOf("digisos.labs.nais.io") >= 0) {
             return getAbsoluteApiUrl(withAccessToken);
         }

--- a/src/nav-soknad/utils/rest-utils.ts
+++ b/src/nav-soknad/utils/rest-utils.ts
@@ -96,9 +96,9 @@ function getRedirectOrigin() {
 }
 
 export function getRedirectPath(): string {
-    const currentOrigin = getRedirectOrigin();
+    const redirectOrigin = getRedirectOrigin();
     const gotoParameter = "?goto=" + getGotoPathname();
-    const redirectPath = currentOrigin + getRedirectPathname() + gotoParameter;
+    const redirectPath = redirectOrigin + getRedirectPathname() + gotoParameter;
     return "redirect=" + redirectPath;
 }
 


### PR DESCRIPTION
* Fjerner ubrukte preprod-ingresser og la til www-*.dev.nav.no, slik at soknaden kan kjøre på samme domene som loginservice.
* Dersom gammel ingress for preprod blir brukt (www-q*.nav.no), vil vi la loginservice redirecte til ny ingress (www-q*.dev.nav.no)
Dette fordi at applikasjonen må være på samme domene som loginservice, hvis ikke vil ikke cookies bli satt og innlogging vil bli mistlykket.