### PR TITLE
Kun sjekke om adressevalg er pending dersom på side 1

### DIFF
--- a/src/nav-soknad/containers/StegMedNavigasjon.tsx
+++ b/src/nav-soknad/containers/StegMedNavigasjon.tsx
@@ -154,12 +154,14 @@ const StegMedNavigasjon = (
         }
     };
 
-    const nextButtonPending = soknad.sendSoknadPending || isAdresseValgRestPending;
     const {skjemaConfig, stegKey, ikon, children} = props;
 
     const {feil, visValideringsfeil} = validering;
 
     const aktivtStegConfig: SkjemaSteg | undefined = skjemaConfig.steg.find((s) => s.key === stegKey);
+
+    const nextButtonPending =
+        soknad.sendSoknadPending || aktivtStegConfig?.key === "kontakt" ? isAdresseValgRestPending : false;
 
     const erOppsummering: boolean = aktivtStegConfig ? aktivtStegConfig.type === SkjemaStegType.oppsummering : false;
     const stegTittel = getIntlTextOrKey(intl, `${stegKey}.tittel`);


### PR DESCRIPTION
initialState for adressevalg sin RestStatus er 'INITIALISERT'. Ved reload av eks side 2 ville "Gå videre" knappen vi disabled siden adressevalg ikke ble lastet inn. Vi ønsker kun å gjøre denne sjekken på side 1. Før levering av søknad på side 9 skal adressevalg lastes inn på nytt og valideres der.