### PR TITLE
Dispatcher egen action for å sette sendSoknadPending siden sagaen kjører før reduceren oppdaterer state

### DIFF
--- a/src/digisos/redux/soknad/soknadActionTypes.ts
+++ b/src/digisos/redux/soknad/soknadActionTypes.ts
@@ -13,6 +13,7 @@ export enum SoknadActionTypeKeys {
     FORTSETT_SOKNAD = "soknad/FORTSETT_SOKNAD",
     SLETT_SOKNAD = "soknad/SLETT_SOKNAD",
     SLETT_SOKNAD_OK = "soknad/SLETT_SOKNAD_OK",
+    SEND_SOKNAD_KNAPP_PENDING = "soknad/SEND_SOKNAD_KNAPP_PENDING",
     SEND_SOKNAD = "soknad/SEND_SOKNAD",
     SEND_SOKNAD_OK = "soknad/SEND_SOKNAD_OK",
 
@@ -58,6 +59,7 @@ export type SoknadActionType =
     | FortsettSoknadAction
     | SlettSoknadAction
     | SlettSoknadOkAction
+    | SendSoknadPendingAction
     | SendSoknadAction
     | SendSoknadOkAction
     | GetErSystemdataEndret
@@ -173,6 +175,10 @@ export interface HentSoknaOkAction {
     type: SoknadActionTypeKeys.HENT_SOKNAD_OK;
     xsrfCookieReceived: boolean;
     behandlingsId: string;
+}
+
+export interface SendSoknadPendingAction {
+    type: SoknadActionTypeKeys.SEND_SOKNAD_KNAPP_PENDING;
 }
 
 export interface SendSoknadAction {

--- a/src/digisos/redux/soknad/soknadActions.ts
+++ b/src/digisos/redux/soknad/soknadActions.ts
@@ -52,6 +52,12 @@ export function hentSoknadOk(xsrfCookieReceived: boolean, behandlingsId: string)
     };
 }
 
+export function sendSoknadPending(): SoknadActionType {
+    return {
+        type: SoknadActionTypeKeys.SEND_SOKNAD_KNAPP_PENDING,
+    };
+}
+
 export function sendSoknad(behandlingsId: string): SoknadActionType {
     return {
         type: SoknadActionTypeKeys.SEND_SOKNAD,
@@ -133,26 +139,30 @@ export const setErSystemdataEndret = (erSystemdataEndret: boolean): SoknadAction
     };
 };
 
-export const oppdaterSamtykke = (behandlingsId: string, harSamtykket: boolean, samtykker: Samtykke[]): SoknadActionType => {
+export const oppdaterSamtykke = (
+    behandlingsId: string,
+    harSamtykket: boolean,
+    samtykker: Samtykke[]
+): SoknadActionType => {
     return {
         type: SoknadActionTypeKeys.OPPDATER_SAMTYKKE,
         behandlingsId: behandlingsId,
         harSamtykket: harSamtykket,
-        samtykker: samtykker
+        samtykker: samtykker,
     };
 };
 
 export function hentSamtykker(behandlingsId: string): SoknadActionType {
     return {
         type: SoknadActionTypeKeys.HENT_SAMTYKKE,
-        behandlingsId
+        behandlingsId,
     };
 }
 
 export function hentSamtykkerOk(samtykker: Samtykke[]): SoknadActionType {
     return {
         type: SoknadActionTypeKeys.HENT_SAMTYKKE_OK,
-        samtykker
+        samtykker,
     };
 }
 

--- a/src/digisos/redux/soknad/soknadReducer.ts
+++ b/src/digisos/redux/soknad/soknadReducer.ts
@@ -140,6 +140,11 @@ export default (state: SoknadState = defaultState, action: SoknadActionType) => 
                 sendSoknadPending: true,
                 showSendingFeiletPanel: false,
             };
+        case SoknadActionTypeKeys.SEND_SOKNAD_KNAPP_PENDING:
+            return {
+                ...state,
+                sendSoknadPending: true,
+            };
         case SoknadActionTypeKeys.SEND_SOKNAD_OK:
             return {
                 ...state,

--- a/src/nav-soknad/containers/StegMedNavigasjon.tsx
+++ b/src/nav-soknad/containers/StegMedNavigasjon.tsx
@@ -167,7 +167,7 @@ const StegMedNavigasjon = (
     const aktivtStegConfig: SkjemaSteg | undefined = skjemaConfig.steg.find((s) => s.key === stegKey);
 
     const nextButtonPending =
-        soknad.sendSoknadPending || aktivtStegConfig?.key === "kontakt" ? isAdresseValgRestPending : false;
+        soknad.sendSoknadPending || (aktivtStegConfig?.key === "kontakt" ? isAdresseValgRestPending : false);
 
     const erOppsummering: boolean = aktivtStegConfig ? aktivtStegConfig.type === SkjemaStegType.oppsummering : false;
     const stegTittel = getIntlTextOrKey(intl, `${stegKey}.tittel`);

--- a/src/nav-soknad/containers/StegMedNavigasjon.tsx
+++ b/src/nav-soknad/containers/StegMedNavigasjon.tsx
@@ -14,7 +14,12 @@ import {REST_STATUS, SkjemaConfig, SkjemaSteg, SkjemaStegType} from "../../digis
 import {ValideringsFeilKode} from "../../digisos/redux/reduxTypes";
 import {setVisBekreftMangler} from "../../digisos/redux/oppsummering/oppsummeringActions";
 import {getIntlTextOrKey, scrollToTop} from "../utils";
-import {avbrytSoknad, resetSendSoknadServiceUnavailable, sendSoknad} from "../../digisos/redux/soknad/soknadActions";
+import {
+    avbrytSoknad,
+    resetSendSoknadServiceUnavailable,
+    sendSoknad,
+    sendSoknadPending,
+} from "../../digisos/redux/soknad/soknadActions";
 import {gaTilbake, gaVidere, tilSteg} from "../../digisos/redux/navigasjon/navigasjonActions";
 import {loggInfo} from "../../digisos/redux/navlogger/navloggerActions";
 import AppBanner from "../components/appHeader/AppHeader";
@@ -100,6 +105,7 @@ const StegMedNavigasjon = (
             if (aktivtSteg.type === SkjemaStegType.oppsummering) {
                 if (oppsummeringBekreftet) {
                     loggAdresseTypeTilGrafana();
+                    dispatch(sendSoknadPending());
                     dispatch(sendSoknad(behandlingsId));
                 } else {
                     dispatch(setVisBekreftMangler(true));


### PR DESCRIPTION
Det kan virke som om actions som plukkes opp av både saga og reducer blir plukket opp av sagaen først. Hvis fetch requestet i sagaen tar litt tid, kan dette åpne for at bruker trykker på send flere ganger.

Ideelt sett skulle jeg gjerne ha holdt staten for sending utenfor redux, men tror det krever litt mer omskriving. Tar det gjerne som en egen PR hvis det er stemning for å skrive om. :)