### PR TITLE
Feature/teamdigisos namespace erstatter q1

### DIFF
--- a/.github/workflows/deploy_dev-sbs-intern_github.yml
+++ b/.github/workflows/deploy_dev-sbs-intern_github.yml
@@ -1,9 +1,9 @@
-name: Deploy q1
+name: Deploy dev-sbs intern
 on: workflow_dispatch
 
 jobs:
   deploy:
-    name: Deploy to q1
+    name: Deploy dev-sbs intern
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -14,13 +14,13 @@ jobs:
           PROJECT_NAME=$(echo ${{ github.repository }} | cut -d/ -f2)
           echo "IMAGE=docker.pkg.github.com/${{ github.repository }}/$PROJECT_NAME:${{ steps.get-latest-tag.outputs.tag }}" >> $GITHUB_ENV
 
-      - name: Deploy til q1
+      - name: Deploy
         uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           RESOURCE: nais.yaml
           CLUSTER: dev-sbs
-          VARS: nais/dev/q1.json
+          VARS: nais/dev/dev-sbs-intern.json
           REF: ${{ steps.get-latest-tag.outputs.tag }}
           PRINT_PAYLOAD: true
           IMAGE: ${{ env.IMAGE }}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Besøk http://localhost:3000/sosialhjelp/soknad/mock-login
 
 ```javascript
 export function getApiBaseUrl(): string {
-    if (erDev()) {
+    if (erLocalhost()) {
         // Kjør mot lokal sendsoknad
         // return "http://localhost:8189/sendsoknad/";
         return "http://localhost:3001/";

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ export function getApiBaseUrl(): string {
 
 -   Åpne `http://localhost:3000/sosialhjelp/soknad/informasjon` i nettleseren.
 
+## Manuell deploy:
+
+Ved bruk av [cli](https://github.com/navikt/sosialhjelp-ci):
+
+-   `deploy labs-gcp` (`labs-gcp2`, `labs-gcp3`)
+-   `deploy dev-gcp`
+-   `deploy q0`
+-   `deploy dev-sbs-intern`
+-   `deploy prod`
+
 ## Tekster
 
 Tekstene ligger i repoet `sosialhjelp-soknad-server` med felles byggejobb på `cisbl.devillo.no`. Tekstendringer blir automatisk

--- a/nais/dev/dev-sbs-intern.json
+++ b/nais/dev/dev-sbs-intern.json
@@ -1,8 +1,8 @@
 {
-  "applicationName": "sosialhjelp-soknad",
-  "namespace": "q1",
+  "applicationName": "sosialhjelp-soknad-intern",
+  "namespace": "teamdigisos",
   "ingresses": [
-    "https://sosialhjelp-soknad-q1.dev-sbs.nais.io/",
+    "https://sosialhjelp-soknad-intern.dev.nav.no/",
     "https://www-q1.dev.nav.no/sosialhjelp/soknad",
     "https://www-q1.nav.no/sosialhjelp/soknad"
   ],

--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -1,4 +1,4 @@
-import {erDev} from "../nav-soknad/utils/rest-utils";
+import {erLocalhost} from "../nav-soknad/utils/rest-utils";
 
 export const CONTEXT_PATH = "sosialhjelp/soknad";
 export const API_CONTEXT_PATH = "sosialhjelp/soknad-api";
@@ -9,7 +9,7 @@ export const GCP_API_APP_NAME = "sosialhjelp-soknad-api";
 
 export const getContextPathForStaticContent = (): string => {
     const context_path = getContextPathFromWindowLocation(window.location.pathname);
-    return erDev() ? "" : context_path;
+    return erLocalhost() ? "" : context_path;
 };
 
 export const getContextPathFromWindowLocation = (pathname: string): string => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,7 +20,7 @@ import sagas from "./rootSaga";
 import IntlProvider from "./intlProvider";
 import App from "./digisos";
 import {loggException} from "./digisos/redux/navlogger/navloggerActions";
-import {erDev, erQ} from "./nav-soknad/utils/rest-utils";
+import {erLocalhost, erDevSbs} from "./nav-soknad/utils/rest-utils";
 import {avbrytSoknad} from "./digisos/redux/soknad/soknadActions";
 import {NAVIGASJONSPROMT} from "./nav-soknad/utils";
 import {visSoknadAlleredeSendtPrompt} from "./digisos/redux/ettersendelse/ettersendelseActions";
@@ -48,7 +48,7 @@ const history = require("history").createBrowserHistory({
     basename: getContextPathBasename(),
 });
 
-if (erDev() || erQ()) {
+if (erLocalhost() || erDevSbs()) {
     Sentry.init({
         dsn: "https://f3482eab7c994893bf44bcb26a0c8e68@sentry.gc.nav.no/14",
     });
@@ -58,7 +58,7 @@ if (erDev() || erQ()) {
 function configureStore() {
     const w: any = window as any;
 
-    const composeEnhancers = erDev() ? w.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose : compose;
+    const composeEnhancers = erLocalhost() ? w.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose : compose;
 
     const saga = createSagaMiddleware();
 

--- a/src/nav-soknad/utils/rest-utils.ts
+++ b/src/nav-soknad/utils/rest-utils.ts
@@ -11,12 +11,12 @@ import {
 import {REST_FEIL} from "../../digisos/redux/soknad/soknadTypes";
 import {NavLogEntry, NavLogLevel} from "../../digisos/redux/navlogger/navloggerTypes";
 
-export function erDev(): boolean {
+export function erLocalhost(): boolean {
     const url = window.location.href;
     return url.indexOf("localhost") >= 0 || url.indexOf("devillo.no:3000") >= 0 || url.indexOf("localhost:8080") >= 0;
 }
 
-export function erQ(): boolean {
+export function erDevSbs(): boolean {
     const url = window.location.href;
     return url.indexOf("www-q0") >= 0 || url.indexOf("www-q1") >= 0;
 }
@@ -36,7 +36,7 @@ export function kjorerJetty(): boolean {
 export function getApiBaseUrl(withAccessToken?: boolean): string {
     const apiContextPath = withAccessToken ? API_CONTEXT_PATH_WITH_ACCESS_TOKEN : API_CONTEXT_PATH;
 
-    if (erDev()) {
+    if (erLocalhost()) {
         // Kjør mot lokal sosialhjelp-soknad-api:
         return `http://localhost:8181/${API_CONTEXT_PATH}/`;
 
@@ -64,7 +64,7 @@ export function getApiBaseUrl(withAccessToken?: boolean): string {
 }
 
 export function getInnsynUrl(): string {
-    if (erDev()) {
+    if (erLocalhost()) {
         return `http://localhost:3000/${INNSYN_CONTEXT_PATH}/`; // Endre port så det passer med porten sosialhjelp-innsyn kjører på lokalt hos deg
     }
 
@@ -82,7 +82,7 @@ export function getAbsoluteApiUrlRegex(pathname: string, withAccessToken?: boole
 }
 
 function determineCredentialsParameter() {
-    return window.location.origin.indexOf("nais.oera") || erDev() ? "include" : "same-origin";
+    return window.location.origin.indexOf("nais.oera") || erLocalhost() ? "include" : "same-origin";
 }
 
 function getRedirectOrigin() {
@@ -122,7 +122,7 @@ export function parseGotoValueFromSearchParameters(searchParameters: string): st
 }
 
 function getServletBaseUrl(): string {
-    if (erDev()) {
+    if (erLocalhost()) {
         return "http://localhost:3001/sendsoknad/";
     }
     return `/${CONTEXT_PATH}/`;


### PR DESCRIPTION
Legger til sosialhjelp-soknad-intern som erstatter q1 (og overtar q1-ingresser)
Oppdaterer readme
Renamer `erQ` -> `erDevSbs` og `erDev` -> `erLocalhost`