### PR TITLE
Setter riktig URL for unleash

### DIFF
--- a/nais.yaml
+++ b/nais.yaml
@@ -45,3 +45,5 @@ spec:
   env:
     - name: APPRES_CMS_URL
       value: {{appresCmsUrl}}
+    - name: UNLEASH_API_URL
+      value: https://unleash.nais.io/api/


### PR DESCRIPTION
unleash-proxy blir skrudd av i morgen. Vi kan dytte ut denne PRen dersom oppdatert URL ikke blir satt som default i pus-dekoratøren.