### PR TITLE
Korrigerer statsborgerskap ukjent

### DIFF
--- a/src/digisos/mock/mockbruker/index.tsx
+++ b/src/digisos/mock/mockbruker/index.tsx
@@ -743,11 +743,11 @@ class MockBruker extends React.Component<Props, OwnState> {
                             <option value="USA" key="USA">
                                 USA
                             </option>
-                            <option value="xxx" key="xxx">
-                                xxx (Statsløs)
+                            <option value="XXX" key="XXX">
+                                XXX (Statsløs)
                             </option>
-                            <option value="???" key="???">
-                                ??? (Mangler opplysninger)
+                            <option value="XUK" key="XUK">
+                                XUK (Ukjent)
                             </option>
                         </Select>
                     </MockDataBolkWrapper>

--- a/src/digisos/skjema/personopplysninger/personalia/BasisPersonalia.tsx
+++ b/src/digisos/skjema/personopplysninger/personalia/BasisPersonalia.tsx
@@ -29,7 +29,7 @@ const BasisPersonaliaView = () => {
     if (statsborgerskap === "XXX" || statsborgerskap === "xxx") {
         statsborgerskap = "Statsløs";
         statsborgerskapVisning = <span>{statsborgerskap}</span>;
-    } else if (statsborgerskap === "XUK" || statsborgerskap === null) {
+    } else if (statsborgerskap === "???" || statsborgerskap === "XUK" || statsborgerskap === null) {
         statsborgerskap = "Vi har ikke opplysninger om ditt statsborgerskap";
         statsborgerskapVisning = <span>{statsborgerskap}</span>;
     }

--- a/src/digisos/skjema/personopplysninger/personalia/BasisPersonalia.tsx
+++ b/src/digisos/skjema/personopplysninger/personalia/BasisPersonalia.tsx
@@ -29,7 +29,7 @@ const BasisPersonaliaView = () => {
     if (statsborgerskap === "XXX" || statsborgerskap === "xxx") {
         statsborgerskap = "Statsløs";
         statsborgerskapVisning = <span>{statsborgerskap}</span>;
-    } else if (statsborgerskap === "???" || statsborgerskap === null) {
+    } else if (statsborgerskap === "XUK" || statsborgerskap === null) {
         statsborgerskap = "Vi har ikke opplysninger om ditt statsborgerskap";
         statsborgerskapVisning = <span>{statsborgerskap}</span>;
     }


### PR DESCRIPTION
Støtter `???` (TPS) og `XUK` (PDL) som koder for Ukjent statsborgerskap. Bruker PDL-verdien i mock