### PR TITLE
Legger til beforeunload-handler dersom bruker har valgt filer men ikke sendt inn slik at vise varsel

### DIFF
--- a/src/digisos/skjema/ettersendelse/index.tsx
+++ b/src/digisos/skjema/ettersendelse/index.tsx
@@ -64,6 +64,23 @@ class Ettersendelse extends React.Component<Props, OwnState> {
         }
     }
 
+    componentDidUpdate() {
+        if (this.hasUndeliveredFiles()) {
+            window.addEventListener("beforeunload", this.alertUser);
+        } else {
+            window.removeEventListener("beforeunload", this.alertUser);
+        }
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener("beforeunload", this.alertUser);
+    }
+
+    alertUser(event: any) {
+        event.preventDefault();
+        event.returnValue = "";
+    }
+
     lesBrukerbehandlingskjedeId() {
         let brukerbehandlingskjedeId = this.props.brukerbehandlingskjedeId;
         if (!brukerbehandlingskjedeId) {
@@ -123,6 +140,10 @@ class Ettersendelse extends React.Component<Props, OwnState> {
 
     isEttersendelseAktivert() {
         return this.props.originalSoknad != null && this.props.originalSoknad.orgnummer != null;
+    }
+
+    hasUndeliveredFiles() {
+        return this.props.manglendeVedlegg.filter((vedlegg) => vedlegg.filer.length > 0).length > 0;
     }
 
     render() {


### PR DESCRIPTION
Dette vil gi et standard varsel til bruker dersom de prøver å lukke vinduet og ikke har sendt inn vedlegg. 