### PR TITLE
Digisos-1887: Stegindikator-fix

### DIFF
--- a/src/nav-soknad/containers/StegMedNavigasjon.tsx
+++ b/src/nav-soknad/containers/StegMedNavigasjon.tsx
@@ -102,6 +102,17 @@ const StegMedNavigasjon = (
         }
     };
 
+    const kanGaTilSkjemasteg = (aktivtSteg: SkjemaSteg | undefined): boolean => {
+        if (aktivtSteg && behandlingsId) {
+            const valgtNavEnhet = finnSoknadsMottaker();
+            if (erPaStegEnOgValgtNavEnhetErUgyldig(aktivtSteg.stegnummer, valgtNavEnhet)) {
+                handleNavEnhetErUgyldigFeil(valgtNavEnhet);
+                return false;
+            }
+        }
+        return true;
+    };
+
     const handleGaVidere = (aktivtSteg: SkjemaSteg) => {
         if (behandlingsId) {
             if (aktivtSteg.type === SkjemaStegType.oppsummering) {
@@ -224,6 +235,7 @@ const StegMedNavigasjon = (
                                         index: s.stegnummer - 1,
                                     };
                                 })}
+                                onBeforeChange={() => kanGaTilSkjemasteg(aktivtStegConfig)}
                                 onChange={(s: number) => handleGaTilSkjemaSteg(aktivtStegConfig, s + 1)}
                             />
                         </div>


### PR DESCRIPTION
### Før:
Start ny søknad og stå på side 1 - uten å velge adresse\
- Klikk på 2 i stegindikatoren (du får noen valideringsfeil)
- Klikk på 3 i stegindikatoren
- Klikk på 4 i stegindikatoren
- osv.

**Faktisk Resulta**t:
Stegindikatoren viser at du har navigart til steg 2 (og så 4, og så 6…) uten at du har det. Annenhver gang du navigerer med stegindikatoren (3, 5, 7 osv.) viser den at du er på steg 1 igjen.

**Forventet resultat**:
Stegindikatoren burde vise korrekt steg, i dette tilfellet steg 1

---
### Etter
Nå viser ikke stegindikatoren at man har navigert vekk fra side 1 uten at man faktisk har det.