### PR TITLE
Fjerner en ensom, ubrukelig dato 

### DIFF
--- a/src/digisos/skjema/ettersendelse/index.tsx
+++ b/src/digisos/skjema/ettersendelse/index.tsx
@@ -235,7 +235,7 @@ class Ettersendelse extends React.Component<Props, OwnState> {
                             {antallManglendeVedlegg > 0 && (
                                 <span>
                                     <Undertittel>Vedlegg mangler</Undertittel>
-                                    <div>{datoManglendeVedlegg}</div>
+                                    <div>Sist oppdatert {datoManglendeVedlegg}</div>
                                 </span>
                             )}
                             {antallManglendeVedlegg === 0 && (

--- a/src/digisos/skjema/ettersendelse/index.tsx
+++ b/src/digisos/skjema/ettersendelse/index.tsx
@@ -120,18 +120,6 @@ class Ettersendelse extends React.Component<Props, OwnState> {
         }
     }
 
-    manglendeVedleggDato() {
-        const {originalSoknad, ettersendelser} = this.props;
-        let datoManglendeVedlegg: string = "";
-        if (originalSoknad) {
-            datoManglendeVedlegg = originalSoknad.innsendtDato;
-        }
-        if (ettersendelser && ettersendelser.length > 0) {
-            datoManglendeVedlegg = ettersendelser[ettersendelser.length - 1].innsendtDato;
-        }
-        return datoManglendeVedlegg;
-    }
-
     antallManglendeVedlegg() {
         return this.props.manglendeVedlegg.filter((item: any) => {
             return !(item.type === "annet|annet");
@@ -149,7 +137,6 @@ class Ettersendelse extends React.Component<Props, OwnState> {
     render() {
         const {originalSoknad, ettersendelser, nedetidstart, nedetidslutt, isNedetid} = this.props;
         const antallManglendeVedlegg = this.antallManglendeVedlegg();
-        const datoManglendeVedlegg = this.manglendeVedleggDato();
         const ettersendelseAktivert = this.isEttersendelseAktivert();
 
         const opprettNyEttersendelseFeilet: boolean =
@@ -235,7 +222,7 @@ class Ettersendelse extends React.Component<Props, OwnState> {
                             {antallManglendeVedlegg > 0 && (
                                 <span>
                                     <Undertittel>Vedlegg mangler</Undertittel>
-                                    <div>Sist oppdatert {datoManglendeVedlegg}</div>
+                                    <p>Det gjenstår {antallManglendeVedlegg} vedlegg</p>
                                 </span>
                             )}
                             {antallManglendeVedlegg === 0 && (


### PR DESCRIPTION
Brukeren får alle nødvendige datoer over. Fjerner denne i samarbeid med Lovise og endrer til en tekst om antall vedlegg som gjenstår.
Før: 
![image](https://user-images.githubusercontent.com/4296877/107391248-cd13e980-6af8-11eb-9a97-987a0811bc25.png)
Nå: 
![image](https://user-images.githubusercontent.com/4296877/107391251-cdac8000-6af8-11eb-8bec-598b9ec8d96f.png)

