### PR TITLE
Legger ved attributt for om ny forside skal vises ved logging til Amplitude

### DIFF
--- a/src/digisos/informasjon/index.tsx
+++ b/src/digisos/informasjon/index.tsx
@@ -63,6 +63,7 @@ const Informasjon = () => {
     const startSoknad = () => {
         logAmplitudeEvent("skjema startet", {
             antallNyligInnsendteSoknader,
+            enableModalV2,
             ...createSkjemaEventData(),
         });
         dispatch(opprettSoknad(intl));


### PR DESCRIPTION
Legger inn denne nå, slik at vi kan få verifisert at det ikke er stor variasjon mellom A og B gruppene før vi starter A/B test på ny forside.