### PR TITLE
Skriver om informasjonspanel, fjerner animasjoner som ikke virket og flytter logikk for visning til komponentene som rendrer panelet

### DIFF
--- a/src/digisos/skjema/familie/sivilstatus/SivilstatusComponent.tsx
+++ b/src/digisos/skjema/familie/sivilstatus/SivilstatusComponent.tsx
@@ -114,16 +114,14 @@ const SivilstatusComponent = () => {
                     onClick={(verdi) => onClickSivilstatus(verdi)}
                 />
             </Sporsmal>
-            <Informasjonspanel
-                synlig={sivilstatus === Status.GIFT}
-                farge={DigisosFarge.VIKTIG}
-                ikon={InformasjonspanelIkon.ELLA}
-            >
-                <h4 className="skjema-sporsmal__infotekst__tittel">
-                    <FormattedMessage id="system.familie.sivilstatus.informasjonspanel.tittel" />
-                </h4>
-                <FormattedMessage id="system.familie.sivilstatus.informasjonspanel.tekst" />
-            </Informasjonspanel>
+            {sivilstatus === Status.GIFT && (
+                <Informasjonspanel farge={DigisosFarge.VIKTIG} ikon={InformasjonspanelIkon.ELLA}>
+                    <h4 className="skjema-sporsmal__infotekst__tittel">
+                        <FormattedMessage id="system.familie.sivilstatus.informasjonspanel.tittel" />
+                    </h4>
+                    <FormattedMessage id="system.familie.sivilstatus.informasjonspanel.tekst" />
+                </Informasjonspanel>
+            )}
         </div>
     );
 };

--- a/src/digisos/skjema/personopplysninger/adresse/SoknadsmottakerInfo.tsx
+++ b/src/digisos/skjema/personopplysninger/adresse/SoknadsmottakerInfo.tsx
@@ -25,7 +25,7 @@ const SoknadsmottakerInfo = (props: {skjul: boolean}) => {
         // GRØNN
         const tekst = `Søknaden vil bli sendt til: ${enhetsnavn}, ${kommunenavn} kommune.`;
         return (
-            <Informasjonspanel ikon={InformasjonspanelIkon.BREVKONVOLUTT} farge={DigisosFarge.SUKSESS} synlig={true}>
+            <Informasjonspanel ikon={InformasjonspanelIkon.BREVKONVOLUTT} farge={DigisosFarge.SUKSESS}>
                 {tekst}
             </Informasjonspanel>
         );

--- a/src/digisos/skjema/utgifterGjeld/boutgifter/Boutgifter.tsx
+++ b/src/digisos/skjema/utgifterGjeld/boutgifter/Boutgifter.tsx
@@ -94,26 +94,24 @@ export const BoutgifterView = () => {
                     {renderCheckBox(BoutgifterKeys.ANNET, "andreutgifter")}
                 </Sporsmal>
             </JaNeiSporsmal>
-            <Informasjonspanel
-                synlig={boutgifter && boutgifter.skalViseInfoVedBekreftelse && boutgifter.bekreftelse === true}
-                ikon={InformasjonspanelIkon.ELLA}
-                farge={DigisosFarge.VIKTIG}
-            >
-                <FormattedMessage
-                    id="informasjon.husbanken.bostotte.v2"
-                    values={{
-                        a: (msg: string) => (
-                            <Lenke
-                                href={intl.formatMessage({id: "informasjon.husbanken.bostotte.url"})}
-                                target="_blank"
-                                rel="noreferrer noopener"
-                            >
-                                {msg}
-                            </Lenke>
-                        ),
-                    }}
-                />
-            </Informasjonspanel>
+            {boutgifter && boutgifter.skalViseInfoVedBekreftelse && boutgifter.bekreftelse === true && (
+                <Informasjonspanel ikon={InformasjonspanelIkon.ELLA} farge={DigisosFarge.VIKTIG}>
+                    <FormattedMessage
+                        id="informasjon.husbanken.bostotte.v2"
+                        values={{
+                            a: (msg: string) => (
+                                <Lenke
+                                    href={intl.formatMessage({id: "informasjon.husbanken.bostotte.url"})}
+                                    target="_blank"
+                                    rel="noreferrer noopener"
+                                >
+                                    {msg}
+                                </Lenke>
+                            ),
+                        }}
+                    />
+                </Informasjonspanel>
+            )}
         </div>
     );
 };

--- a/src/nav-soknad/components/informasjonspanel/index.tsx
+++ b/src/nav-soknad/components/informasjonspanel/index.tsx
@@ -9,14 +9,9 @@ import EllaKompakt from "../svg/EllaKompakt";
 interface OwnProps {
     farge: DigisosFarge;
     children?: any;
-    synlig?: boolean;
     ikon: InformasjonspanelIkon;
     className?: string;
     wrapperClassName?: string;
-}
-
-interface State {
-    vises: boolean;
 }
 
 export enum InformasjonspanelIkon {
@@ -25,41 +20,19 @@ export enum InformasjonspanelIkon {
     HENSYN = "hensyn",
 }
 
-class Informasjonspanel extends React.Component<OwnProps, State> {
-    panelIsMounted: boolean = false;
-
-    constructor(props: OwnProps) {
-        super(props);
-        this.state = {
-            vises: false,
-        };
-    }
-
-    componentDidMount() {
-        this.panelIsMounted = true;
-        setTimeout(() => {
-            if (this.panelIsMounted) {
-                this.setState({vises: true});
-            }
-        }, 200);
-    }
-
-    componentWillUnmount(): void {
-        this.panelIsMounted = false;
-    }
-
-    renderIkon() {
+const Informasjonspanel = (props: OwnProps) => {
+    const renderIkon = () => {
         const iconSize = erMobilVisning() ? 64 : 80;
-        switch (this.props.ikon) {
+        switch (props.ikon) {
             case InformasjonspanelIkon.ELLA: {
                 return (
                     <div>
                         <div className="ikke_mobilvennlig_ikon">
-                            <Ella size={iconSize} visBakgrundsSirkel={true} bakgrundsFarge={this.props.farge} />
+                            <Ella size={iconSize} visBakgrundsSirkel={true} bakgrundsFarge={props.farge} />
                         </div>
 
                         <div className="mobilvennlig_ikon">
-                            <EllaKompakt bakgrundsFarge={this.props.farge} />
+                            <EllaKompakt bakgrundsFarge={props.farge} />
                         </div>
                     </div>
                 );
@@ -67,54 +40,39 @@ class Informasjonspanel extends React.Component<OwnProps, State> {
             case InformasjonspanelIkon.BREVKONVOLUTT: {
                 return (
                     <div>
-                        <Brevkonvolutt size={iconSize} visBakgrundsSirkel={true} bakgrundsFarge={this.props.farge} />
+                        <Brevkonvolutt size={iconSize} visBakgrundsSirkel={true} bakgrundsFarge={props.farge} />
                     </div>
                 );
             }
             case InformasjonspanelIkon.HENSYN: {
                 return (
                     <div>
-                        <Hensyn size={iconSize} visBakgrundsSirkel={true} bakgrundsFarge={this.props.farge} />
+                        <Hensyn size={iconSize} visBakgrundsSirkel={true} bakgrundsFarge={props.farge} />
                     </div>
                 );
             }
             default: {
                 return (
                     <div>
-                        <Ella size={iconSize} visBakgrundsSirkel={true} bakgrundsFarge={this.props.farge} />
+                        <Ella size={iconSize} visBakgrundsSirkel={true} bakgrundsFarge={props.farge} />
                     </div>
                 );
             }
         }
-    }
+    };
 
-    renderContent(fadeIn: boolean) {
-        const styleClassName = "skjema-informasjonspanel--" + this.props.farge;
+    const styleClassName = "skjema-informasjonspanel--" + props.farge;
 
-        return (
-            <div className={"skjema-informasjonspanel-wrapper " + this.props.className}>
-                <div
-                    className={
-                        "skjema-informasjonspanel " +
-                        styleClassName +
-                        (this.props.synlig || fadeIn === false ? " skjema-informasjonspanel__synlig" : "")
-                    }
-                >
-                    <div>{this.renderIkon()}</div>
-                    <span>{this.props.children}</span>
+    return (
+        <div className={"react-collapse-wrapper"}>
+            <div className={"skjema-informasjonspanel-wrapper " + props.className}>
+                <div className={"skjema-informasjonspanel " + styleClassName}>
+                    <div>{renderIkon()}</div>
+                    <span>{props.children}</span>
                 </div>
             </div>
-        );
-    }
-
-    render() {
-        const isOpened = this.state.vises && this.props.synlig;
-        if (typeof isOpened === "undefined") {
-            return this.renderContent(false);
-        } else {
-            return <div className={"react-collapse-wrapper"}>{this.renderContent(true)}</div>;
-        }
-    }
-}
+        </div>
+    );
+};
 
 export default Informasjonspanel;

--- a/src/nav-soknad/components/informasjonspanel/informasjonspanel.less
+++ b/src/nav-soknad/components/informasjonspanel/informasjonspanel.less
@@ -3,46 +3,9 @@
     border-radius: 0.5rem;
     background-color: @white;
 
-    transition: opacity 0.5s;
-    opacity: 0;
-
-    animation-name: fjernInfoPanel;
-    animation-delay: 0.5s;
-    animation-duration: 0.01s;
-    animation-fill-mode: forwards;
-    animation-iteration-count: 1;
-    animation-timing-function: ease;
-
     .skjema-sporsmal__infotekst__tittel {
         margin-top: 0;
         margin-bottom: 0;
-    }
-
-    &__synlig {
-        opacity: 1;
-
-        animation-name: visInfoPanel;
-        animation-delay: 0.5s;
-        animation-duration: 0.01s;
-        animation-fill-mode: forwards;
-        animation-iteration-count: 1;
-        animation-timing-function: ease;
-
-        & > div {
-            opacity: 1;
-        }
-    }
-}
-
-@keyframes visInfoPanel {
-    100% {
-        height: initial;
-    }
-}
-
-@keyframes fjernInfoPanel {
-    100% {
-        height: 0;
     }
 }
 
@@ -54,14 +17,7 @@
     display: block;
 }
 
-.react-collapse-wrapper {
-    padding-bottom: 1rem;
-}
-
 @media @desktop {
-    .react-collapse-wrapper {
-    }
-
     .skjema-informasjonspanel {
         padding: 2rem 1.5rem 2rem 3.5rem;
 


### PR DESCRIPTION
Dette panelet er ganske likt `nav-frontend-veilederpanel`. Kanskje vi på sikt kan bytte ut dette når det kommer en oppdatert versjon i `ds-react`.