### PR TITLE
POST-kall for å oppdatere samtykke for skatteetaten går ikke via login-api

### DIFF
--- a/src/digisos/redux/soknadsdata/soknadsdataActions.ts
+++ b/src/digisos/redux/soknadsdata/soknadsdataActions.ts
@@ -55,11 +55,12 @@ export function settSamtykkeOgOppdaterData(
     sti: string,
     harSamtykke: boolean,
     dataSti: null | string,
+    withAccessToken: boolean,
     dispatch: Dispatch
 ) {
     const restStatusSti = "inntekt/samtykke";
     dispatch(settRestStatus(restStatusSti, REST_STATUS.PENDING));
-    fetchPost(soknadsdataUrl(brukerBehandlingId, sti), JSON.stringify(harSamtykke), true)
+    fetchPost(soknadsdataUrl(brukerBehandlingId, sti), JSON.stringify(harSamtykke), withAccessToken)
         .then((response: any) => {
             dispatch(settRestStatus(restStatusSti, REST_STATUS.OK));
             if (dataSti && dataSti.length > 1) {

--- a/src/digisos/skjema/inntektFormue/bostotte/Bostotte.tsx
+++ b/src/digisos/skjema/inntektFormue/bostotte/Bostotte.tsx
@@ -71,6 +71,7 @@ const BostotteView = () => {
                 SoknadsSti.BOSTOTTE_SAMTYKKE,
                 nyttHarSamtykke,
                 SoknadsSti.BOSTOTTE,
+                true,
                 dispatch
             );
         }

--- a/src/digisos/skjema/inntektFormue/skattbarInntekt/index.tsx
+++ b/src/digisos/skjema/inntektFormue/skattbarInntekt/index.tsx
@@ -46,6 +46,7 @@ const Skatt = () => {
                 SoknadsSti.SKATTBARINNTEKT_SAMTYKKE,
                 nyttHarSamtykke,
                 SoknadsSti.SKATTBARINNTEKT,
+                false,
                 dispatch
             );
         }


### PR DESCRIPTION
Dette post-kallet trigger henting av data fra skatteetaten, og når vi bruker maskinporten skal vi ikke gå via login-api.

Sees i sammenheng med https://github.com/navikt/sosialhjelp-soknad-api/pull/900. 

Merges etter at featuretoggle (https://unleash.nais.io/#/features/strategies/sosialhjelp.soknad.skatteetaten-maskinporten-enabled) er enabled i prod-sbs