### PR TITLE
Mulig å manuelt registrere barn

### DIFF
--- a/src/digisos/skjema/familie/forsorgerplikt/BrukerregistrerteBarn.tsx
+++ b/src/digisos/skjema/familie/forsorgerplikt/BrukerregistrerteBarn.tsx
@@ -16,7 +16,6 @@ import {State} from "../../../redux/reducers";
 import {oppdaterSoknadsdataSti, SoknadsSti} from "../../../redux/soknadsdata/soknadsdataReducer";
 import {clearValideringsfeil, setValideringsfeil} from "../../../redux/validering/valideringActions";
 import {lagreSoknadsdata, setPath} from "../../../redux/soknadsdata/soknadsdataActions";
-import {ValideringsFeilKode} from "../../../redux/validering/valideringActionTypes";
 import styled from "styled-components";
 import {Button} from "@navikt/ds-react";
 

--- a/src/digisos/skjema/familie/forsorgerplikt/BrukerregistrerteBarn.tsx
+++ b/src/digisos/skjema/familie/forsorgerplikt/BrukerregistrerteBarn.tsx
@@ -134,8 +134,9 @@ const BrukerregistrerteBarn = () => {
             let fodselsdato: string = barnet.barn.fodselsdato ? barnet.barn.fodselsdato : "";
             if (fodselsdato === "") {
                 barnet.barn.fodselsdato = null;
+                dispatch(clearValideringsfeil(TEXT_KEY_FNR + i));
+                setDatoFormatFeilIndex(-1);
             }
-            let harNoeInnhold = harInnhold(barnet);
             if (fodselsdato !== "") {
                 fodselsdato = konverterFraISODato(fodselsdato);
                 feilkodeFodselsdato = fdato(fodselsdato);
@@ -152,45 +153,12 @@ const BrukerregistrerteBarn = () => {
                     fodselsdato = konverterTilISODato(fodselsdato);
                     barnet.barn.fodselsdato = fodselsdato;
                 }
-            } else {
-                dispatch(clearValideringsfeil(TEXT_KEY_FNR + i));
-                setDatoFormatFeilIndex(-1);
-                if (harNoeInnhold) {
-                    dispatch(setValideringsfeil(ValideringsFeilKode.PAKREVD, TEXT_KEY_FNR + i));
-                    ingenFeilKoder = false;
-                }
-            }
-            if (!harNoeInnhold || (barnet.barn.navn && barnet.barn.navn.fornavn && barnet.barn.navn.fornavn !== "")) {
-                dispatch(clearValideringsfeil(TEXT_KEY_FIRST_NAME + i));
-            } else {
-                dispatch(setValideringsfeil(ValideringsFeilKode.PAKREVD, TEXT_KEY_FIRST_NAME + i));
-                ingenFeilKoder = false;
-            }
-            if (
-                !harNoeInnhold ||
-                (barnet.barn.navn && barnet.barn.navn.etternavn && barnet.barn.navn.etternavn !== "")
-            ) {
-                dispatch(clearValideringsfeil(TEXT_KEY_LAST_NAME + i));
-            } else {
-                dispatch(setValideringsfeil(ValideringsFeilKode.PAKREVD, TEXT_KEY_LAST_NAME + i));
-                ingenFeilKoder = false;
             }
         }
         if (ingenFeilKoder && behandlingsId) {
             lagreSoknadsdata(behandlingsId, SoknadsSti.FORSORGERPLIKT, forsorgerplikt, dispatch);
         }
     };
-
-    function harInnhold(barnet: Barn): boolean {
-        const fodselsdato: string = barnet.barn.fodselsdato ? barnet.barn.fodselsdato : "";
-        if (barnet.barn.navn) {
-            const fornavn: string = barnet.barn.navn.fornavn ?? "";
-            const mellomnavn: string = barnet.barn.navn.mellomnavn ?? "";
-            const etternavn: string = barnet.barn.navn.etternavn ?? "";
-            return fodselsdato !== "" || fornavn !== "" || mellomnavn !== "" || etternavn !== "";
-        }
-        return fodselsdato !== "";
-    }
 
     return (
         <Sporsmal sprakNokkel="familierelasjon.faktum.leggtil" legendTittelStyle={LegendTittleStyle.FET_NORMAL}>
@@ -217,7 +185,7 @@ const BrukerregistrerteBarn = () => {
                                 onFocus={() => onFokus(index)}
                                 faktumKey={TEXT_KEY_FIRST_NAME + index}
                                 textKey={TEXT_KEY + ".fornavn"}
-                                required={true}
+                                required={false}
                             />
 
                             <InputEnhanced
@@ -242,7 +210,7 @@ const BrukerregistrerteBarn = () => {
                                 onFocus={() => onFokus(index)}
                                 faktumKey={TEXT_KEY_LAST_NAME + index}
                                 textKey={TEXT_KEY + ".etternavn"}
-                                required={true}
+                                required={false}
                             />
 
                             <InputEnhanced
@@ -257,7 +225,7 @@ const BrukerregistrerteBarn = () => {
                                 onFocus={() => onFokus(index)}
                                 faktumKey={TEXT_KEY_FNR + index}
                                 textKey={TEXT_KEY_FNR}
-                                required={true}
+                                required={false}
                             />
 
                             <div className="skjema-sporsmal skjema-sporsmal__innhold barn_samvaer_block">

--- a/src/digisos/skjema/familie/forsorgerplikt/ForsorgerPlikt.tsx
+++ b/src/digisos/skjema/familie/forsorgerplikt/ForsorgerPlikt.tsx
@@ -1,7 +1,7 @@
 import {FormattedMessage} from "react-intl";
 import * as React from "react";
 import {useDispatch, useSelector} from "react-redux";
-import {useState, useEffect} from "react";
+import {useState, useEffect, useContext} from "react";
 
 import {SoknadsSti} from "../../../redux/soknadsdata/soknadsdataReducer";
 import Sporsmal, {LegendTittleStyle} from "../../../../nav-soknad/components/sporsmal/Sporsmal";
@@ -11,10 +11,13 @@ import TextPlaceholder from "../../../../nav-soknad/components/animasjoner/place
 import {REST_STATUS} from "../../../redux/soknad/soknadTypes";
 import {State} from "../../../redux/reducers";
 import {hentSoknadsdata} from "../../../redux/soknadsdata/soknadsdataActions";
+import {FeatureToggleContext} from "../../../../LoadContainer";
 import BrukerregistrerteBarn from "./BrukerregistrerteBarn";
 
 const ForsorgerPliktView = () => {
     const [oppstartsModus, setOppstartsModus] = useState(true);
+
+    const {leggeTilBarn} = useContext(FeatureToggleContext);
 
     const dispatch = useDispatch();
 
@@ -60,7 +63,7 @@ const ForsorgerPliktView = () => {
                         <FormattedMessage id="familierelasjon.ingen_registrerte_barn_tekst" />
                     </b>
                 </p>
-                <BrukerregistrerteBarn />
+                {leggeTilBarn && <BrukerregistrerteBarn />}
                 {brukerregistrertAnsvar && antallBrukerregistrerteBarn > 0 && <Barnebidrag />}
             </Sporsmal>
         );
@@ -79,7 +82,7 @@ const ForsorgerPliktView = () => {
                 </p>
 
                 <RegistrerteBarn />
-                <BrukerregistrerteBarn />
+                {leggeTilBarn && <BrukerregistrerteBarn />}
                 <Barnebidrag />
             </Sporsmal>
         );

--- a/src/digisos/skjema/familie/forsorgerplikt/ForsorgerPlikt.tsx
+++ b/src/digisos/skjema/familie/forsorgerplikt/ForsorgerPlikt.tsx
@@ -11,6 +11,7 @@ import TextPlaceholder from "../../../../nav-soknad/components/animasjoner/place
 import {REST_STATUS} from "../../../redux/soknad/soknadTypes";
 import {State} from "../../../redux/reducers";
 import {hentSoknadsdata} from "../../../redux/soknadsdata/soknadsdataActions";
+import BrukerregistrerteBarn from "./BrukerregistrerteBarn";
 
 const ForsorgerPliktView = () => {
     const [oppstartsModus, setOppstartsModus] = useState(true);
@@ -59,7 +60,7 @@ const ForsorgerPliktView = () => {
                         <FormattedMessage id="familierelasjon.ingen_registrerte_barn_tekst" />
                     </b>
                 </p>
-                {/*<BrukerregistrerteBarn/> TODO: Kommentert ut intil alle FSLer er klare. */}
+                <BrukerregistrerteBarn />
                 {brukerregistrertAnsvar && antallBrukerregistrerteBarn > 0 && <Barnebidrag />}
             </Sporsmal>
         );
@@ -78,7 +79,7 @@ const ForsorgerPliktView = () => {
                 </p>
 
                 <RegistrerteBarn />
-                {/*<BrukerregistrerteBarn/> TODO: Kommentert ut intil alle FSLer er klare. */}
+                <BrukerregistrerteBarn />
                 <Barnebidrag />
             </Sporsmal>
         );


### PR DESCRIPTION
Edit: Har lagt på feature-toggling slik at denne skal kunne flettes inn, uten at vi skrur den på i prod.

Vi ønsker å gjøre utfylling likt resten av søknaden, så ingen av feltene er påkrevd. Kun validering på dato dersom denne er utfylt. (Eks er det også mulig å manuelt legge til ektefelle / partner uten navn).

- [x] Brukerregistrerte barn må vises på oppsummeringssiden og i PDF (dette løses i backend)
- [ ] FSL og kommuner må få testet