### PR TITLE
Teller bruk av systemdata til amplitude

### DIFF
--- a/src/nav-soknad/utils/amplitude.ts
+++ b/src/nav-soknad/utils/amplitude.ts
@@ -24,7 +24,8 @@ export function logAmplitudeEvent(eventName: string, eventData?: Record<string, 
     });
 }
 
-export const createSkjemaEventData = () => ({
+export const createSkjemaEventData = (eventData?: Record<string, unknown>) => ({
     skjemaId: "sosialhjelpsoknad",
     skjemanavn: "Soknad om økonomisk sosialhjelp",
+    ...eventData,
 });


### PR DESCRIPTION
Et par enkle målinger for å sjekke hvor ofte brukere endrer adresse, telefon og kontonummer, samt hvor ofte det samtykkes til å hente data fra skatt. 