### PR TITLE
getNavEnhet trenger ikke routes via login-api

### DIFF
--- a/src/nav-soknad/containers/containerUtils.tsx
+++ b/src/nav-soknad/containers/containerUtils.tsx
@@ -49,7 +49,7 @@ export const sjekkOmValgtNavEnhetErGyldig = (
     dispatch: Dispatch,
     callbackHvisGyldigEllerIkkeSatt: () => void
 ) => {
-    fetchToJson(soknadsdataUrl(behandlingsId, SoknadsSti.VALGT_NAV_ENHET), true)
+    fetchToJson(soknadsdataUrl(behandlingsId, SoknadsSti.VALGT_NAV_ENHET))
         .then((response) => {
             if (responseIsOfTypeNavEnhet(response)) {
                 const valgtNavKontor: NavEnhet | undefined = response as NavEnhet;


### PR DESCRIPTION
nå som maskinporten brukes for å hente kommuneinfo fra Fiks trenger ikke kall til "hentValgtNavEnhet" routes via login-api.

Testet OK i dev.