### PR TITLE
Hotfix for 404-feil

### DIFF
--- a/src/digisos/hovedmeny/index.tsx
+++ b/src/digisos/hovedmeny/index.tsx
@@ -20,6 +20,8 @@ const Informasjon = () => {
         new Date()
     );
 
+    sessionStorage.removeItem("sistLagretSoknad");
+
     if (!harTilgang) return <IkkeTilgang />;
 
     return (

--- a/src/lib/sendSoknad.ts
+++ b/src/lib/sendSoknad.ts
@@ -28,9 +28,11 @@ export const sendSoknad = async (behandlingsId: string, dispatch: Dispatch<AnyAc
         dispatch(sendSoknadOk(id));
 
         const redirectUrl: Record<SendTilUrlFrontendSendtTil, string> = {
-            FIKS_DIGISOS_API: `${getInnsynUrl()}${response.id}/status`,
-            SVARUT: `${basePath}/skjema/${response.id}/ettersendelse`,
+            FIKS_DIGISOS_API: `${getInnsynUrl()}${id}/status`,
+            SVARUT: `${basePath}/skjema/${id}/ettersendelse`,
         };
+
+        sessionStorage.setItem("sistLagretSoknad", behandlingsId);
 
         return redirectUrl[sendtTil];
     } catch (reason) {

--- a/src/nav-soknad/components/SkjemaSteg/SkjemaSteg.tsx
+++ b/src/nav-soknad/components/SkjemaSteg/SkjemaSteg.tsx
@@ -122,7 +122,8 @@ export const SkjemaSteg = ({skjemaConfig, steg, ikon, children}: StegMedNavigasj
     if (showServerFeil) return <ServerFeil />;
 
     // Hotfix for issue where users pressing "back" from innsyn results in 404 message
-    // In the future we will handle
+    // In the future we will handle this by redirecting on HTTP 410 Gone but this
+    // solves the primary UX issue.
     if (showSideIkkeFunnet) {
         if (sessionStorage.getItem("sistLagretSoknad") === behandlingsId) {
             logInfo("Videresender bruker på bakgrunn av sistLagretSoknad");

--- a/src/nav-soknad/components/SkjemaSteg/SkjemaSteg.tsx
+++ b/src/nav-soknad/components/SkjemaSteg/SkjemaSteg.tsx
@@ -14,13 +14,15 @@ import {DigisosSkjemaStegKey, SkjemaConfig} from "./digisosSkjema";
 import {SkjemaStegNavStepper} from "./SkjemaStegNavStepper";
 import {useSkjemaNavigation} from "./useSkjemaNavigation";
 import SkjemaStegNavKnapper from "./SkjemaStegNavKnapper";
-import {useParams} from "react-router";
+import {useNavigate, useParams} from "react-router";
 import ServerFeil from "../../feilsider/ServerFeil";
 import SideIkkeFunnet from "../../feilsider/SideIkkeFunnet";
 import TimeoutBox from "../timeoutbox/TimeoutBox";
 import {AvbrytSoknad} from "../avbrytsoknad/AvbrytSoknad";
 import {getSoknad} from "../../../lib/getSoknad";
 import {Trans, useTranslation} from "react-i18next";
+import {setShowPageNotFound} from "../../../digisos/redux/soknad/soknadActions";
+import {logInfo} from "../../utils/loggerUtils";
 
 export type UrlParams = Record<"behandlingsId" | "skjemaSteg", string>;
 
@@ -101,6 +103,7 @@ export const SkjemaSteg = ({skjemaConfig, steg, ikon, children}: StegMedNavigasj
     }, []);
 
     const {feil, visValideringsfeil} = validering;
+    const navigate = useNavigate();
 
     const stegTittel = getIntlTextOrKey(t, `${steg}.tittel`);
     const documentTitle = t(skjemaConfig.tittelId);
@@ -118,8 +121,16 @@ export const SkjemaSteg = ({skjemaConfig, steg, ikon, children}: StegMedNavigasj
 
     if (showServerFeil) return <ServerFeil />;
 
-    if (showSideIkkeFunnet) return <SideIkkeFunnet />;
-
+    // Hotfix for issue where users pressing "back" from innsyn results in 404 message
+    // In the future we will handle
+    if (showSideIkkeFunnet) {
+        if (sessionStorage.getItem("sistLagretSoknad") === behandlingsId) {
+            logInfo("Videresender bruker på bakgrunn av sistLagretSoknad");
+            sessionStorage.removeItem("sistLagretSoknad");
+            dispatch(setShowPageNotFound(false));
+            navigate("/informasjon");
+        } else return <SideIkkeFunnet />;
+    }
     return (
         <div className="pb-4 lg:pb-40 bg-green-500/20">
             <AppBanner />


### PR DESCRIPTION
Dersom en bruker trykker tilbake fra innsyn for å gå tilbake til sosialhjelp-siden, får de en 404-melding. en naturlig reaksjon er da å prøve "Tilbake"-knappen igjen, men bruker ender opp med å steppe tilbake i skjemaet, og gir som regel opp å trykke tilbake før de når /informasjon.

Ved vellykket lagring av søknad lagrer vi behandlingsId i session storage. Om frontend ser en 404-feil, sjekker den etter samsvar mellom sessionStorage og forsøkt behandlingsId. Om ja, sletter den denne nøkkelen. Hovedmenyen sletter også denne nøkkelen. Logger som info for brukerinnsikt.