### PR TITLE
WCAG-ledetekst-i-navn-structure

### DIFF
--- a/src/skjema/04-familie/sivilstatus/EktefelleDetaljer.tsx
+++ b/src/skjema/04-familie/sivilstatus/EktefelleDetaljer.tsx
@@ -45,7 +45,7 @@ const EktefelleDetaljer = () => {
             </Sporsmal>
             {!harDiskresjonskode && (
                 <Alert variant={"warning"}>
-                    <Heading level={"4"} size={"small"} spacing>
+                    <Heading level={"2"} size={"small"} spacing>
                         {t("system.familie.sivilstatus.informasjonspanel.tittel")}
                     </Heading>
                     <BodyShort>{t("system.familie.sivilstatus.informasjonspanel.tekst")}</BodyShort>

--- a/src/sosialhjelp.less
+++ b/src/sosialhjelp.less
@@ -67,15 +67,6 @@ body {
     }
 }
 
-// FIXME: This kludge is here to fix headlines awaiting the merge of the i18next PR
-.skjema-sporsmal {
-    h2 {
-        font-weight: 600;
-        font-size: 26px;
-        margin-bottom: 1rem;
-    }
-}
-
 .inputPanelPadding {
     height: 3.5rem;
 }


### PR DESCRIPTION
Endrer fra level 4 til level 2 for å opprettholde strukturen. 
Fjerner også css klassen skjema-sporsmal siden den virker unødvendig basert på commiten den er assosiert med. 