### PR TITLE
WCAG-Hoppe-over-blokker

### DIFF
--- a/src/nav-soknad/components/SkjemaSteg/SkjemaStegLegacy.tsx
+++ b/src/nav-soknad/components/SkjemaSteg/SkjemaStegLegacy.tsx
@@ -77,24 +77,26 @@ export const SkjemaStegLegacy = ({skjemaConfig, steg, ikon, children, onSend}: S
         <div className="pb-4 lg:pb-40 bg-digisosGronnBakgrunn">
             <AppBanner />
             <SkjemaStegNavStepperLegacy skjemaConfig={skjemaConfig} aktivtSteg={steg} onStepChange={gotoPage} />
-            <div className={"max-w-3xl mx-auto skjema-steg skjema-content"}>
-                <NedetidPanel varselType={"infoside"} />
-                <Feiloppsummering valideringsfeil={feil} visFeilliste={visValideringsfeil} />
-                <div className={"bg-white mx-auto rounded-2xl px-4 md:px-12 lg:px-24 space-y-8 pt-8"}>
-                    <SkjemaStegHeading ikon={ikon} stegTittel={stegTittel} />
-                    <div className={"space-y-12 lg:space-y-24"}>{children}</div>
-                    <TimeoutBox sessionDurationInMinutes={30} showWarningerAfterMinutes={25} />
-                    <AvbrytSoknadModal open={avbrytModalOpen} onClose={() => setAvbrytModalOpen(false)} />
-                    {aktivtSteg.id !== 1 && !(aktivtSteg.id === 9 && nedetid?.isNedetid) && <NavEnhetInaktiv />}
-                    <SkjemaStegNavKnapperLegacy
-                        skjemaConfig={skjemaConfig}
-                        steg={skjemaConfig.steg[steg]}
-                        goToStep={gotoPage}
-                        loading={enFilLastesOpp}
-                        onSend={onSend}
-                    />
+            <main>
+                <div className={"max-w-3xl mx-auto skjema-steg skjema-content"}>
+                    <NedetidPanel varselType={"infoside"} />
+                    <Feiloppsummering valideringsfeil={feil} visFeilliste={visValideringsfeil} />
+                    <div className={"bg-white mx-auto rounded-2xl px-4 md:px-12 lg:px-24 space-y-8 pt-8"}>
+                        <SkjemaStegHeading ikon={ikon} stegTittel={stegTittel} />
+                        <div className={"space-y-12 lg:space-y-24"}>{children}</div>
+                        <TimeoutBox sessionDurationInMinutes={30} showWarningerAfterMinutes={25} />
+                        <AvbrytSoknadModal open={avbrytModalOpen} onClose={() => setAvbrytModalOpen(false)} />
+                        {aktivtSteg.id !== 1 && !(aktivtSteg.id === 9 && nedetid?.isNedetid) && <NavEnhetInaktiv />}
+                        <SkjemaStegNavKnapperLegacy
+                            skjemaConfig={skjemaConfig}
+                            steg={skjemaConfig.steg[steg]}
+                            goToStep={gotoPage}
+                            loading={enFilLastesOpp}
+                            onSend={onSend}
+                        />
+                    </div>
                 </div>
-            </div>
+            </main>
         </div>
     );
 };

--- a/src/nav-soknad/components/SkjemaSteg/ny/SkjemaSteg.tsx
+++ b/src/nav-soknad/components/SkjemaSteg/ny/SkjemaSteg.tsx
@@ -77,14 +77,16 @@ const SkjemaTitle = ({className}: {className?: string}) => {
 };
 
 const SkjemaContent = ({children, className}: {children: ReactNode; className?: string}) => (
-    <div
-        className={cx(
-            "bg-white mx-auto rounded-2xl px-4 md:px-12 lg:px-24 pt-8 pb-8 mb-16 space-y-12 lg:space-y-24",
-            className
-        )}
-    >
-        {children}
-    </div>
+    <main>
+        <div
+            className={cx(
+                "bg-white mx-auto rounded-2xl px-4 md:px-12 lg:px-24 pt-8 pb-8 mb-16 space-y-12 lg:space-y-24",
+                className
+            )}
+        >
+            {children}
+        </div>
+    </main>
 );
 
 const SkjemaSteg = ({page, children, onRequestNavigation}: SkjemaStegProps) => {

--- a/src/nav-soknad/components/SkjemaSteg/ny/SkjemaStegStepper.tsx
+++ b/src/nav-soknad/components/SkjemaSteg/ny/SkjemaStegStepper.tsx
@@ -26,7 +26,9 @@ export const SkjemaStegStepper = () => {
                 onStepChange={(s: number) => requestNavigation(s)}
             >
                 {[1, 2, 3, 4, 5, 6, 7, 8].map((key) => (
-                    <Stepper.Step key={key}>{t(SkjemaHeadings[page].tittel)}</Stepper.Step>
+                    <Stepper.Step key={key} as="button">
+                        {t(SkjemaHeadings[page].tittel)}
+                    </Stepper.Step>
                 ))}
             </Stepper>
         </div>


### PR DESCRIPTION
Siden det er færre enn 5 steg til hovedinnholdet holder det å wrappe hovedinholdet i main tags (dropper altså hopp til hovedinnhold link). 
Fikser også slik at alle steg i stepperen er tilgjengelig med tastatur navigering. 