### PR TITLE
error-displays-prematurely

### DIFF
--- a/src/skjema/08-vedlegg/OpplysningInputRad.tsx
+++ b/src/skjema/08-vedlegg/OpplysningInputRad.tsx
@@ -33,7 +33,7 @@ export const OpplysningInputRad = ({
                         <TextField
                             className={cx("pb-2", {"w-32": fieldName !== "beskrivelse"})}
                             label={t(`${textKey}.${fieldName}.label`)}
-                            error={fieldState.error?.message && t(fieldState.error.message)}
+                            error={fieldState.isTouched && fieldState.error?.message && t(fieldState.error.message)}
                             {...field}
                             // To avoid value === null
                             value={field.value || ""}


### PR DESCRIPTION
La til `fieldState.isTouched` til error sjekken på OpplysningInputRad for å unngå feilmelding uten at input feltet er rørt.