### PR TITLE
belopTekstfeltPreprocessor-feilmelding-fix

### DIFF
--- a/src/skjema/08-vedlegg/belopTekstfeltPreprocessor.ts
+++ b/src/skjema/08-vedlegg/belopTekstfeltPreprocessor.ts
@@ -14,6 +14,8 @@ import {logError} from "../../nav-soknad/utils/loggerUtils";
  * @todo Testdekning
  */
 export const belopTekstfeltPreprocessor = (inputString: unknown) => {
+    if (inputString === undefined || inputString === null) return null;
+
     if (typeof inputString === "number") return inputString;
 
     if (typeof inputString !== "string") {


### PR DESCRIPTION
Legger til en if for håndtering av undefined og null verdi. 

Med denne endringen, hvis skjemafeltene belop, brutto, netto, renter, og avdrag er initialt tomme (enten undefined eller null), vil preprocessoren nå korrekt returnere null i stedet for å kaste en feil. Dette bør forhindre at en feil utløses når du navigerer til siden før noen data har blitt skrevet inn i skjemaet.