### PR TITLE
Fikser bug som spente bein på backend

### DIFF
--- a/src/digisos/redux/soknadsdata/soknadsdataReducer.ts
+++ b/src/digisos/redux/soknadsdata/soknadsdataReducer.ts
@@ -6,7 +6,7 @@ import {Bostotte, initialBostotteState} from "../../../skjema/06-inntektFormue/b
 import {initialUtbetalingerState, Utbetalinger} from "../../../skjema/06-inntektFormue/utbetalinger/utbetalingerTypes";
 import {initialVerdierState, Verdier} from "../../../skjema/06-inntektFormue/verdier/VerdierTypes";
 import {initialFormueState, Formue} from "../../../skjema/06-inntektFormue/formue/FormueTypes";
-import {initialBoutgifterState, Boutgifter} from "../../../skjema/07-utgifterGjeld/boutgifter/BoutgifterTypes";
+import {initialBoutgifterState} from "../../../skjema/07-utgifterGjeld/boutgifter/BoutgifterTypes";
 import {
     initialBarneutgifterState,
     Barneutgifter,
@@ -19,6 +19,7 @@ import {
 import {Systeminntekter, initialSysteminntekter} from "../../../skjema/06-inntektFormue/navytelser/navYtelserTypes";
 import {Studielan, initialStudielanState} from "../../../skjema/06-inntektFormue/studielan/StudielanTypes";
 import {REST_STATUS} from "./soknadsdataTypes";
+import {BoutgifterFrontend} from "../../../generated/model";
 
 export enum SoknadsdataActionTypeKeys {
     OPPDATER_SOKNADSDATA_STI = "soknadsdata/OPPDATER_STI",
@@ -78,7 +79,7 @@ export const initialInntektState: Inntekt = {
 };
 
 export interface Utgifter {
-    boutgifter: Boutgifter;
+    boutgifter: BoutgifterFrontend;
     barneutgifter: Barneutgifter;
 }
 
@@ -117,7 +118,7 @@ export type SoknadsdataType =
     | Utgifter
     | Utbetalinger
     | Barneutgifter
-    | Boutgifter
+    | BoutgifterFrontend
     | SkattbarInntektInfo;
 
 interface SoknadsdataActionType {
@@ -161,20 +162,16 @@ const reducer = (state: Soknadsdata = initialSoknadsdataState, action: Soknadsda
     }
 };
 
-export const settRestStatus = (sti: string, restStatus: REST_STATUS): SoknadsdataActionType => {
-    return {
-        type: SoknadsdataActionTypeKeys.SETT_REST_STATUS,
-        sti,
-        restStatus,
-    };
-};
+export const settRestStatus = (sti: string, restStatus: REST_STATUS): SoknadsdataActionType => ({
+    type: SoknadsdataActionTypeKeys.SETT_REST_STATUS,
+    sti,
+    restStatus,
+});
 
-export const oppdaterSoknadsdataSti = (sti: string, verdi: SoknadsdataType | null): SoknadsdataActionType => {
-    return {
-        type: SoknadsdataActionTypeKeys.OPPDATER_SOKNADSDATA_STI,
-        sti,
-        verdi,
-    };
-};
+export const oppdaterSoknadsdataSti = (sti: string, verdi: SoknadsdataType | null): SoknadsdataActionType => ({
+    type: SoknadsdataActionTypeKeys.OPPDATER_SOKNADSDATA_STI,
+    sti,
+    verdi,
+});
 
 export default reducer;

--- a/src/skjema/07-utgifterGjeld/boutgifter/Boutgifter.tsx
+++ b/src/skjema/07-utgifterGjeld/boutgifter/Boutgifter.tsx
@@ -7,34 +7,48 @@ import Informasjonspanel from "../../../nav-soknad/components/Informasjonspanel"
 import {Link} from "@navikt/ds-react";
 import {Trans, useTranslation} from "react-i18next";
 import {useSoknadsdata} from "../../../digisos/redux/soknadsdata/useSoknadsdata";
-import {Boutgifter, BoutgifterKeys} from "./BoutgifterTypes";
+import {BoutgifterKeys} from "./BoutgifterTypes";
 
 const BOUTGIFTER = "utgifter.boutgift";
 
 export const BoutgifterView = () => {
-    const {soknadsdata, lagre, oppdater} = useSoknadsdata(SoknadsSti.BOUTGIFTER);
-    const boutgifter: Boutgifter = soknadsdata.utgifter.boutgifter;
+    const {
+        soknadsdata: {
+            utgifter: {boutgifter},
+        },
+        lagre,
+        oppdater,
+    } = useSoknadsdata(SoknadsSti.BOUTGIFTER);
     const {t} = useTranslation("skjema");
 
-    const handleClickRadio = (idToToggle: BoutgifterKeys) => {
-        boutgifter[idToToggle] = !boutgifter[idToToggle];
+    const setCheckboxValue = (idToToggle: BoutgifterKeys, value: boolean) => {
+        boutgifter[idToToggle] = value;
+        // FIXME: Vet ikke hvorfor dette er nødvendig,
+        //  dette er en feil som går langt inn i backend.
+        boutgifter.bekreftelse = harSvartJa();
         oppdater(boutgifter);
         lagre(boutgifter);
     };
 
-    const renderCheckBox = (navn: BoutgifterKeys, textKey: string) => {
-        const isChecked = !!boutgifter[navn];
+    const renderCheckBox = (navn: BoutgifterKeys, textKey: string) => (
+        <CheckboxPanel
+            id={"boutgifter_" + navn + "_checkbox"}
+            name={navn}
+            checked={boutgifter[navn]}
+            label={t(BOUTGIFTER + ".true.type." + textKey)}
+            onClick={(value) => setCheckboxValue(navn, value)}
+        />
+    );
 
-        return (
-            <CheckboxPanel
-                id={"boutgifter_" + navn + "_checkbox"}
-                name={navn}
-                checked={isChecked}
-                label={t(BOUTGIFTER + ".true.type." + textKey)}
-                onClick={() => handleClickRadio(navn)}
-            />
-        );
-    };
+    const harSvartJa = () =>
+        [
+            BoutgifterKeys.HUSLEIE,
+            BoutgifterKeys.STROM,
+            BoutgifterKeys.KOMMUNALAVGIFT,
+            BoutgifterKeys.OPPVARMING,
+            BoutgifterKeys.BOLIGLAN,
+            BoutgifterKeys.ANNET,
+        ].some((key) => boutgifter[key]);
 
     return (
         <div className="skjema-sporsmal">
@@ -49,7 +63,7 @@ export const BoutgifterView = () => {
                 {renderCheckBox(BoutgifterKeys.BOLIGLAN, BoutgifterKeys.BOLIGLAN)}
                 {renderCheckBox(BoutgifterKeys.ANNET, "andreutgifter")}
             </Sporsmal>
-            {boutgifter && boutgifter.skalViseInfoVedBekreftelse && boutgifter.bekreftelse === true && (
+            {boutgifter?.skalViseInfoVedBekreftelse && boutgifter?.bekreftelse && (
                 <Informasjonspanel ikon={"ella"} farge="viktig">
                     <Trans
                         t={t}

--- a/src/skjema/07-utgifterGjeld/boutgifter/BoutgifterTypes.tsx
+++ b/src/skjema/07-utgifterGjeld/boutgifter/BoutgifterTypes.tsx
@@ -1,16 +1,7 @@
-export interface Boutgifter {
-    bekreftelse: null | boolean;
-    husleie: boolean;
-    strom: boolean;
-    kommunalAvgift: boolean;
-    oppvarming: boolean;
-    boliglan: boolean;
-    annet: boolean;
-    skalViseInfoVedBekreftelse: boolean;
-}
+import {BoutgifterFrontend} from "../../../generated/model";
 
-export const initialBoutgifterState: Boutgifter = {
-    bekreftelse: null,
+export const initialBoutgifterState: BoutgifterFrontend = {
+    bekreftelse: true,
     husleie: false,
     strom: false,
     kommunalAvgift: false,
@@ -21,7 +12,6 @@ export const initialBoutgifterState: Boutgifter = {
 };
 
 export enum BoutgifterKeys {
-    BEKREFTELSE = "bekreftelse",
     HUSLEIE = "husleie",
     STROM = "strom",
     KOMMUNALAVGIFT = "kommunalAvgift",


### PR DESCRIPTION
Da spørsmålet om boutgifter ble fjernet, ble ikke funksjonaliteten oppdatert.

Siden frontendtypen ikke er korrekt ble det ikke oppdaget ved statisk analyse.

Setter nå bekreftelse til true eller false avhengig av om noen boutgifter er markert.

Koden må fremdeles fikses på backend, men dette løser det umiddelbare problemet. 

Bruker nå Swagger-deriverte datatyper for Boutgifter, så det vil bli ajour.