### PR TITLE
B** Fikset ektefelle data som sendes mot backend.

### DIFF
--- a/src/lib/hooks/data/useSivilstatus.tsx
+++ b/src/lib/hooks/data/useSivilstatus.tsx
@@ -25,7 +25,8 @@ export const useSivilstatus = () => {
             ...sivilstatus,
             sivilstatus: nySivilstatus,
             kildeErSystem: false,
-            ektefelle,
+            ektefelle: nySivilstatus === "gift" ? ektefelle : undefined,
+            borSammenMed: nySivilstatus === "gift" ? sivilstatus?.borSammenMed : undefined,
         };
 
         await updateSivilstatus(behandlingsId, oppdatert);


### PR DESCRIPTION
Dersom sivilstatus != "gift", ikke send "ektefelle" eller "borSammenMed".

Løser 500-feil ved PUT. Mer "ordentlig" løsning er i [PR mot backend](https://github.com/navikt/sosialhjelp-soknad-api/pull/1764)