### PR TITLE
b - teksten "arbeidsforhold.infotekst" vises under oppsummering

### DIFF
--- a/src/pages/09-oppsummering/mapChangedIntlKeys.tsx
+++ b/src/pages/09-oppsummering/mapChangedIntlKeys.tsx
@@ -4,6 +4,7 @@ const INTL_KEYS_MAP: Record<string, string> = {
     "dinsituasjon.studerer.true.grad.sporsmal": "dinsituasjon.studerer.grad.sporsmal",
     "dinsituasjon.studerer.true.grad.deltid": "dinsituasjon.studerer.grad.deltid",
     "dinsituasjon.studerer.true.grad.heltid": "dinsituasjon.studerer.grad.heltid",
+    "arbeidsforhold.infotekst": "arbeidsforhold.infotekst_del1",
 };
 
 // Midlertidig hack for å fortsatt bruke gamle oppsummering inntil brukertest av ny


### PR DESCRIPTION
"arbeidsforhold.infotekst" har nu blitt delt opp i "arbeidsforhold.infotekst_del1" og "arbeidsforhold.infotekst_del2, dette blir fikset med å legge til i INTL_KEYS_MAP den nye tekstnøkkelen