### PR TITLE
b - Det hoppet frem mye "Error: Missing loginUrl in 401 response"

### DIFF
--- a/src/lib/api/error/isLoginError.ts
+++ b/src/lib/api/error/isLoginError.ts
@@ -2,6 +2,7 @@ import {AxiosResponse} from "axios";
 import {UnauthorizedMelding} from "../../../generated/model";
 
 export const isLoginError = (response: AxiosResponse): response is AxiosResponse<UnauthorizedMelding> => {
-    if (!response.data?.loginUrl) throw new Error("Missing loginUrl in 401 response");
-    return response.status === 401;
+    const is401 = response.status === 401;
+    if (is401 && !response.data?.loginUrl) throw new Error("Missing loginUrl in 401 response");
+    return is401;
 };


### PR DESCRIPTION
meldinger på slack, det kan være en litt hickup. For sikkerhet skyld endres const isLoginError til å bare kaste error når loginurl mangler fra 401 respons