### PR TITLE
Wonderwall-støtte for KS- og husbanken-tokens

### DIFF
--- a/.nais/app.yaml
+++ b/.nais/app.yaml
@@ -1,7 +1,7 @@
 apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
-  name: sosialhjelp-soknad-{{postfix}}
+  name: {{ appName }}
   namespace: teamdigisos
   labels:
     team: teamdigisos

--- a/.nais/app.yaml
+++ b/.nais/app.yaml
@@ -17,7 +17,7 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: sosialhjelp-soknad-wonderwall
+        - application: wonderwall-soknad
     outbound:
       rules:
         - application: sosialhjelp-soknad-api

--- a/.nais/app.yaml
+++ b/.nais/app.yaml
@@ -15,6 +15,9 @@ spec:
     - {{url}}
     {{/each}}
   accessPolicy:
+    inbound:
+      rules:
+        - application: sosialhjelp-soknad-wonderwall
     outbound:
       rules:
         - application: sosialhjelp-soknad-api

--- a/.nais/vars/mock.yaml
+++ b/.nais/vars/mock.yaml
@@ -1,4 +1,4 @@
-postfix: mock
+appName: sosialhjelp-soknad-mock
 ingresses:
   - "https://digisos.ekstern.dev.nav.no/sosialhjelp/soknad"
 externalOutboundAccesses:

--- a/.nais/vars/preprod.yaml
+++ b/.nais/vars/preprod.yaml
@@ -5,6 +5,6 @@ externalOutboundAccesses:
   - "dekoratoren.ekstern.dev.nav.no"
   - "digisos.ekstern.dev.nav.no"
   - "www.dev.nav.no"
-idportenEnabled: true
+idportenEnabled: false
 env:
   DEKORATOREN_MILJO: dev

--- a/.nais/vars/preprod.yaml
+++ b/.nais/vars/preprod.yaml
@@ -1,4 +1,4 @@
-postfix: preprod
+appName: sosialhjelp-soknad
 ingresses: []
 externalOutboundAccesses:
   - "dekoratoren.dev.nav.no"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Først, bekreft at en nøkkel eksisterer for kryptering av Wonderwall-sessions i
 
 ```sh
 # Denne er trygg å kjøre uansett, ettersom den vil feile om secret alt eksisterer
-kubectl create secret generic idporten-sso-soknad-redis --from-literal=WONDERWALL_ENCRYPTION_KEY=$(openssl rand -base64 32)
+kubectl create secret generic wonderwall-redis --from-literal=WONDERWALL_ENCRYPTION_KEY=$(openssl rand -base64 32)
 ```
 
 Deretter, sørg for at en passende IDPorten-klient er provisjonert via NAIS:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Først, bekreft at en nøkkel eksisterer for kryptering av Wonderwall-sessions i
 
 ```sh
 # Denne er trygg å kjøre uansett, ettersom den vil feile om secret alt eksisterer
-kubectl create secret generic sosialhjelp-soknad-wonderwall-sessions --from-literal=WONDERWALL_ENCRYPTION_KEY=$(openssl rand -base64 32)
+kubectl create secret generic idporten-sso-soknad-redis --from-literal=WONDERWALL_ENCRYPTION_KEY=$(openssl rand -base64 32)
 ```
 
 Deretter, sørg for at en passende IDPorten-klient er provisjonert via NAIS:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,40 @@ Deploy til dev-gcp gjøres via Github Actions, se: https://github.com/navikt/sos
 
 Da må appen gå via proxy. Url er https://digisos.ekstern.dev.nav.no/sosialhjelp/soknad
 
+## Wonderwall
+
+Vi bruker en litt custom Wonderwall-setup for at scope for KS og Husbanken skal være inkludert.
+
+### Oppsett
+
+Først, bekreft at en nøkkel eksisterer for kryptering av Wonderwall-sessions i Redis:
+
+```sh
+# Denne er trygg å kjøre uansett, ettersom den vil feile om secret alt eksisterer
+kubectl create secret generic sosialhjelp-soknad-wonderwall-sessions --from-literal=WONDERWALL_ENCRYPTION_KEY=$(openssl rand -base64 32)
+```
+
+Deretter, sørg for at en passende IDPorten-klient er provisjonert via NAIS:
+
+```shell
+kubectl apply -f wonderwall/idportenclient.yml
+```
+
+Dette vil føre til opprettelsen av en secret med miljøvariabler for IDporten:
+`IDPORTEN_CLIENT_ID`, `IDPORTEN_CLIENT_JWK`, `IDPORTEN_ISSUER, IDPORTEN_JWKS_URI`, `IDPORTEN_REDIRECT_URI`, `IDPORTEN_TOKEN_ENDPOINT` og `IDPORTEN_WELL_KNOWN_URL`.
+
+Nå kan Wonderwall provisjoneres:
+
+```shell
+kubectl apply -f wonderwall/wonderwall.yml
+```
+
+Notér at i påvente av mer offisiell støtte for ekstra scopes i Wonderwall, er det mulig at `wonderwall.yml` kan måtte tilpasses for det aktuelle miljøet (ingress, env/WONDERWALL_INGRESS og accesspolicy/outbound).
+
+Merk også at accesspolicy må settes på innkommende side i frontend.
+
+Når disse ressursene først er opprettet og konfigurert, trengs ingen fornying for senere deploys.
+
 ## Henvendelser
 
 Spørsmål knyttet til koden eller prosjektet kan rettes mot:

--- a/src/app/soknad-api/[...path]/route.ts
+++ b/src/app/soknad-api/[...path]/route.ts
@@ -11,7 +11,7 @@ export const OPTIONS = proxyMyBackend;
 async function proxyMyBackend(request: Request, {params}: {params: Promise<{path: string[]}>}): Promise<Response> {
     const path = `/sosialhjelp/soknad-api/${(await params).path.join("/")}`;
     const hostname = "sosialhjelp-soknad-api.teamdigisos";
-    logger.info("Proxying request to sosialhjelp-soknad-api.teamdigisos");
+    logger.info(`Proxying request to ${hostname}`);
     logger.info("Authorization: " + request.headers.get("Authorization"));
     logger.info("Path: " + path);
 

--- a/src/app/soknad-api/[...path]/route.ts
+++ b/src/app/soknad-api/[...path]/route.ts
@@ -5,6 +5,7 @@ export const GET = proxyMyBackend;
 export const POST = proxyMyBackend;
 export const PUT = proxyMyBackend;
 export const DELETE = proxyMyBackend;
+export const OPTIONS = proxyMyBackend;
 
 // Remember to export the HTTP verb you want Next to expose
 async function proxyMyBackend(request: Request, {params}: {params: Promise<{path: string[]}>}): Promise<Response> {

--- a/wonderwall/idportenclient.yml
+++ b/wonderwall/idportenclient.yml
@@ -3,7 +3,7 @@ kind: IDPortenClient
 metadata:
   labels:
     team: teamdigisos
-  name: idporten-sso-soknad
+  name: idporten-soknad
   namespace: teamdigisos
 spec:
   accessTokenLifetime: 3600
@@ -18,5 +18,5 @@ spec:
     - openid
     - ks:fiks
     - husbanken:minbostotte
-  secretName: idporten-sso-soknad
+  secretName: idporten-soknad
   sessionLifetime: 21600

--- a/wonderwall/idportenclient.yml
+++ b/wonderwall/idportenclient.yml
@@ -1,0 +1,22 @@
+apiVersion: nais.io/v1
+kind: IDPortenClient
+metadata:
+  labels:
+    team: teamdigisos
+  name: idporten-sso-soknad
+  namespace: teamdigisos
+spec:
+  accessTokenLifetime: 3600
+  clientURI: https://www-preprod.ekstern.dev.nav.no/sosialhjelp/soknad
+  frontchannelLogoutURI: https://www-preprod.ekstern.dev.nav.no/sosialhjelp/soknad/oauth2/logout/frontchannel
+  integrationType: idporten
+  postLogoutRedirectURIs:
+    - https://www-preprod.ekstern.dev.nav.no/sosialhjelp/soknad/oauth2/logout/callback
+  redirectURIs:
+    - https://www-preprod.ekstern.dev.nav.no/sosialhjelp/soknad/oauth2/callback
+  scopes:
+    - openid
+    - ks:fiks
+    - husbanken:minbostotte
+  secretName: idporten-sso-soknad
+  sessionLifetime: 21600

--- a/wonderwall/idportenclient.yml
+++ b/wonderwall/idportenclient.yml
@@ -7,7 +7,7 @@ metadata:
   namespace: teamdigisos
 spec:
   accessTokenLifetime: 3600
-  clientURI: https://www-preprod.ekstern.dev.nav.no/sosialhjelp/soknad
+  clientURI: https://www.nav.no/okonomisk-sosialhjelp
   frontchannelLogoutURI: https://www-preprod.ekstern.dev.nav.no/sosialhjelp/soknad/oauth2/logout/frontchannel
   integrationType: api_klient
   postLogoutRedirectURIs:

--- a/wonderwall/idportenclient.yml
+++ b/wonderwall/idportenclient.yml
@@ -9,7 +9,7 @@ spec:
   accessTokenLifetime: 3600
   clientURI: https://www-preprod.ekstern.dev.nav.no/sosialhjelp/soknad
   frontchannelLogoutURI: https://www-preprod.ekstern.dev.nav.no/sosialhjelp/soknad/oauth2/logout/frontchannel
-  integrationType: idporten
+  integrationType: api_klient
   postLogoutRedirectURIs:
     - https://www-preprod.ekstern.dev.nav.no/sosialhjelp/soknad/oauth2/logout/callback
   redirectURIs:

--- a/wonderwall/wonderwall.yml
+++ b/wonderwall/wonderwall.yml
@@ -1,7 +1,7 @@
 apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
-  name: sosialhjelp-soknad-wonderwall
+  name: wonderwall-soknad
   namespace: teamdigisos
   labels:
     team: teamdigisos
@@ -25,7 +25,7 @@ spec:
       memory: 50Mi
   redis:
     - access: readwrite
-      instance: sessions
+      instance: wonderwall
   liveness:
     initialDelay: 20
     path: /sosialhjelp/soknad/oauth2/ping
@@ -36,8 +36,8 @@ spec:
     min: 1
     max: 1
   envFrom:
-    - secret: idporten-sso-soknad
-    - secret: idporten-sso-soknad-redis
+    - secret: idporten-soknad
+    - secret: wonderwall-redis
   env:
     - name: WONDERWALL_AUTO_LOGIN
       value: "true"
@@ -48,7 +48,7 @@ spec:
     - name: WONDERWALL_INGRESS
       value: https://www-preprod.ekstern.dev.nav.no/sosialhjelp/soknad
     - name: WONDERWALL_UPSTREAM_HOST
-      value: sosialhjelp-soknad-preprod:80
+      value: sosialhjelp-soknad:80
     - name: WONDERWALL_BIND_ADDRESS
       value: 0.0.0.0:8080
     - name: WONDERWALL_METRICS_BIND_ADDRESS
@@ -60,8 +60,8 @@ spec:
     - name: WONDERWALL_LOG_LEVEL
       value: debug
     - name: WONDERWALL_REDIS_URI
-      value: $(REDIS_URI_SESSIONS)
+      value: $(REDIS_URI_WONDERWALL)
     - name: WONDERWALL_REDIS_USERNAME
-      value: $(REDIS_USERNAME_SESSIONS)
+      value: $(REDIS_USERNAME_WONDERWALL)
     - name: WONDERWALL_REDIS_PASSWORD
-      value: $(REDIS_PASSWORD_SESSIONS)
+      value: $(REDIS_PASSWORD_WONDERWALL)

--- a/wonderwall/wonderwall.yml
+++ b/wonderwall/wonderwall.yml
@@ -34,7 +34,7 @@ spec:
     path: /sosialhjelp/soknad/oauth2/ping
   replicas:
     min: 1
-    max: 1
+    max: 2
   envFrom:
     - secret: idporten-soknad
     - secret: wonderwall-redis

--- a/wonderwall/wonderwall.yml
+++ b/wonderwall/wonderwall.yml
@@ -37,7 +37,7 @@ spec:
     max: 1
   envFrom:
     - secret: idporten-sso-soknad
-    - secret: sosialhjelp-soknad-wonderwall-sessions
+    - secret: idporten-sso-soknad-redis
   env:
     - name: WONDERWALL_AUTO_LOGIN
       value: "true"

--- a/wonderwall/wonderwall.yml
+++ b/wonderwall/wonderwall.yml
@@ -1,0 +1,67 @@
+apiVersion: "nais.io/v1alpha1"
+kind: "Application"
+metadata:
+  name: sosialhjelp-soknad-wonderwall
+  namespace: teamdigisos
+  labels:
+    team: teamdigisos
+spec:
+  image: europe-north1-docker.pkg.dev/nais-io/nais/images/wonderwall:latest
+  port: 8080
+  ingresses:
+    - "https://www-preprod.ekstern.dev.nav.no/sosialhjelp/soknad"
+  accessPolicy:
+    outbound:
+      external:
+        - host: test.idporten.no
+      rules:
+        - application: sosialhjelp-soknad
+  resources:
+    limits:
+      cpu: "2"
+      memory: 256Mi
+    requests:
+      cpu: "20m"
+      memory: 50Mi
+  redis:
+    - access: readwrite
+      instance: sessions
+  liveness:
+    initialDelay: 20
+    path: /sosialhjelp/soknad/oauth2/ping
+  readiness:
+    initialDelay: 20
+    path: /sosialhjelp/soknad/oauth2/ping
+  replicas:
+    min: 1
+    max: 1
+  envFrom:
+    - secret: idporten-sso-soknad
+    - secret: sosialhjelp-soknad-wonderwall-sessions
+  env:
+    - name: WONDERWALL_AUTO_LOGIN
+      value: "true"
+    - name: WONDERWALL_OPENID_PROVIDER
+      value: idporten
+    - name: WONDERWALL_OPENID_SCOPES
+      value: ks:fiks,husbanken:minbostotte
+    - name: WONDERWALL_INGRESS
+      value: https://www-preprod.ekstern.dev.nav.no/sosialhjelp/soknad
+    - name: WONDERWALL_UPSTREAM_HOST
+      value: sosialhjelp-soknad-preprod:80
+    - name: WONDERWALL_BIND_ADDRESS
+      value: 0.0.0.0:8080
+    - name: WONDERWALL_METRICS_BIND_ADDRESS
+      value: 0.0.0.0:7565
+    - name: WONDERWALL_SHUTDOWN_GRACEFUL_PERIOD
+      value: 30s
+    - name: WONDERWALL_SHUTDOWN_WAIT_BEFORE_PERIOD
+      value: 7s
+    - name: WONDERWALL_LOG_LEVEL
+      value: debug
+    - name: WONDERWALL_REDIS_URI
+      value: $(REDIS_URI_SESSIONS)
+    - name: WONDERWALL_REDIS_USERNAME
+      value: $(REDIS_USERNAME_SESSIONS)
+    - name: WONDERWALL_REDIS_PASSWORD
+      value: $(REDIS_PASSWORD_SESSIONS)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/680f620f-8683-4674-9320-344e67706990)

Provisjonerer en IDporten-klient via NAIS sin Maskinporten-integrasjon. Har bekreftet at scopes er tilstede.

Merk at Husbanken ikke fungerer, jeg formoder det er i fravær av mockede APIer i preprod?

Om ikke: Trong skrev vi måtte sette `integrationType: api_klient`, er dette evt. problemet?