### PR TITLE
API-klientkode for SSR

### DIFF
--- a/orval.config.ts
+++ b/orval.config.ts
@@ -1,4 +1,5 @@
 import {defineConfig} from "orval";
+import {pascal} from "@orval/core";
 
 export default defineConfig({
     "soknad-api-client-old": {
@@ -16,6 +17,26 @@ export default defineConfig({
             },
             // Vi bruker ikke mocks enda, og avventer ny versjon av orval
             // som støtter msw v2.
+            mock: false,
+        },
+        hooks: {
+            afterAllFilesWrite: "prettier --write",
+        },
+    },
+    "soknad-api-client-old-ssr": {
+        input: "./soknad-api-old.json",
+        output: {
+            mode: "single",
+            target: "src/generated/old-ssr",
+            schemas: "src/generated/old-ssr/model",
+            client: "fetch",
+            override: {
+                mutator: {
+                    path: "./src/lib/api/ssr/authenticatedFetch.ts",
+                    name: "authenticatedFetch",
+                },
+                operationName: ({operationId}) => ssrCamelCasePrefixer(operationId),
+            },
             mock: false,
         },
         hooks: {
@@ -43,6 +64,26 @@ export default defineConfig({
             afterAllFilesWrite: "prettier --write",
         },
     },
+    "soknad-api-client-new-ssr": {
+        input: "./soknad-api-new.json",
+        output: {
+            mode: "single",
+            target: "src/generated/new-ssr",
+            schemas: "src/generated/new-ssr/model",
+            client: "fetch",
+            override: {
+                mutator: {
+                    path: "./src/lib/api/ssr/authenticatedFetch.ts",
+                    name: "authenticatedFetch",
+                },
+                operationName: ({operationId}) => ssrCamelCasePrefixer(operationId),
+            },
+            mock: false,
+        },
+        hooks: {
+            afterAllFilesWrite: "prettier --write",
+        },
+    },
     driftsmeldinger: {
         input: "./driftsmelding-api.json",
         output: {
@@ -62,27 +103,23 @@ export default defineConfig({
             afterAllFilesWrite: "prettier --write",
         },
     },
-    // TODO: Finne løsning for API-bruk på server-side
-    // "soknad-api-ssr": {
-    //     input: "./soknad-api.json",
-    //     output: {
-    //         mode: "tags-split",
-    //         target: "src/generated/server/axiosInstance.ts",
-    //         schemas: "src/generated/server/model",
-    //         client: "axios-functions",
-    //         override: {
-    //             mutator: {
-    //                 path: "./src/lib/api/axiosInstanceSsr.ts",
-    //                 name: "axiosInstance",
-    //             },
-    //             transformer: (operation) => ({...operation, operationName: `${operation.operationName}Ssr`}),
-    //         },
-    //         // Vi bruker ikke mocks enda, og avventer ny versjon av orval
-    //         // som støtter msw v2.
-    //         mock: false,
-    //     },
-    //     hooks: {
-    //         afterAllFilesWrite: "prettier --write",
-    //     },
-    // },
 });
+
+/**
+ * Custom Orval function to prefix methods with "ssr" while retaining camelCase.
+ *
+ * operationIds are not strictly schematically mandated by openapi, but
+ * we can still take them for granted because we use springdoc to generate
+ * schemas for our Spring Boot backends, and springdoc - at least as configured
+ * in soknad-api at the time of writing - always generates an operationId.
+ *
+ * If we're not using those operations in SSR code, we don't have to care them.
+ * So if the schema some day happens to include operations where operationId is missing,
+ * we generate eye-catchingly implausible names for them rather than breaking the build.
+ *
+ * Maybe when the SSR code is used on a majority of pages, we can prefer it's always flagged,
+ * and consider this an error instead.
+ */
+const ssrCamelCasePrefixer = (operationId: string | undefined) => {
+    return `ssr${pascal(operationId ?? "MISSING_OPERATION_ID_IN_SPEC")}`;
+};

--- a/orval.config.ts
+++ b/orval.config.ts
@@ -113,7 +113,7 @@ export default defineConfig({
  * schemas for our Spring Boot backends, and springdoc - at least as configured
  * in soknad-api at the time of writing - always generates an operationId.
  *
- * If we're not using those operations in SSR code, we don't have to care them.
+ * If we're not using those operations, we don't have to care if one pops up unnamed.
  * So if the schema some day happens to include operations where operationId is missing,
  * we generate eye-catchingly implausible names for them rather than breaking the build.
  *

--- a/src/lib/api/ssr/authenticatedFetch.ts
+++ b/src/lib/api/ssr/authenticatedFetch.ts
@@ -1,0 +1,42 @@
+import {cookies, headers} from "next/headers";
+import digisosConfig from "../../config.ts";
+
+const getAuthorizationHeader = async (): Promise<string> => (await headers()).get("authorization") ?? "";
+
+const getRequestCookies = async (): Promise<string> => {
+    const requestCookies = await cookies();
+    return requestCookies
+        .getAll()
+        .map((cookie) => `${cookie.name}=${cookie.value}`)
+        .join("; ");
+};
+
+const getBody = <T>(c: Response | Request): Promise<T> => {
+    const contentType = c.headers.get("content-type");
+    if (contentType?.includes("application/json")) return c.json();
+    return c.text() as Promise<T>;
+};
+
+const getHeaders = async (initHeaders?: HeadersInit): Promise<HeadersInit> => {
+    const headers = new Headers(initHeaders);
+
+    const authHeader = await getAuthorizationHeader();
+    if (authHeader) headers.set("Authorization", authHeader);
+
+    const requestCookies = await getRequestCookies();
+    if (requestCookies) headers.set("Cookie", requestCookies);
+
+    return headers;
+};
+
+export const authenticatedFetch = async <T>(url: string, options: RequestInit = {}): Promise<T> => {
+    const absoluteUrl = new URL(digisosConfig.baseURL + url.slice(1));
+
+    const response = await fetch(absoluteUrl, {...options, headers: await getHeaders(options.headers)});
+    if (!response.ok) throw new Error(`Failed to fetch ${absoluteUrl}: ${response.status} ${response.statusText}`);
+
+    const data = await getBody<T>(response);
+    return {status: response.status, data, headers: response.headers} as T;
+};
+
+export default authenticatedFetch;


### PR DESCRIPTION
Generert API-klientkode og fetcher for bruk av API i SSR.

Bruker fetch, fordi det er enklest og best støttet av NextJS (som har sin egen fetch()-implementasjon)