### PR TITLE
Vis Nav-enhet ved deaktivert mottak, ikke kommunenavn

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -82,11 +82,11 @@
   },
   "NavEnhetInaktiv": {
     "varig": {
-      "melding": "{kommunenavn} municipality cannot accept digital applications.",
+      "melding": "{enhetsnavn} cannot accept digital applications.",
       "forslag": "You can <lenke>apply using a paper form</lenke>."
     },
     "midlertidig": {
-      "melding": "{kommunenavn} municipality cannot accept digital applications right now.",
+      "melding": "{enhetsnavn} cannot accept digital applications right now.",
       "forslag": "<lenke>Apply using a paper form</lenke>, or try again later."
     }
   },

--- a/messages/nb.json
+++ b/messages/nb.json
@@ -82,11 +82,11 @@
   },
   "NavEnhetInaktiv": {
     "varig": {
-      "melding": "{kommunenavn} kommune kan ikke ta i mot digitale søknader.",
+      "melding": "{enhetsnavn} kan ikke ta i mot digitale søknader.",
       "forslag": "Du kan <lenke>søke på papirskjema</lenke>."
     },
     "midlertidig": {
-      "melding": "{kommuneNavn} kommune kan dessverre ikke ta i mot digitale søknader akkurat nå.",
+      "melding": "{enhetsnavn} kan dessverre ikke ta i mot digitale søknader akkurat nå.",
       "forslag": "<lenke>Søk på papirskjema</lenke>, eller prøv igjen senere."
     }
   },

--- a/messages/nn.json
+++ b/messages/nn.json
@@ -82,11 +82,11 @@
   },
   "NavEnhetInaktiv": {
     "varig": {
-      "melding": "{kommunenavn} kommune kan ikkje ta imot digitale søknader.",
+      "melding": "{enhetsnavn} kan ikkje ta imot digitale søknader.",
       "forslag": "Du kan <lenke>søkje på papirskjema</lenke>."
     },
     "midlertidig": {
-      "melding": "{kommunenavn} kommune kan diverre ikkje ta imot digitale søknader akkurat no.",
+      "melding": "{enhetsnavn} kan diverre ikkje ta imot digitale søknader akkurat no.",
       "forslag": "<lenke>Søk på papirskjema</lenke>, eller prøv igjen seinare."
     }
   },

--- a/src/sider/01-personalia/adresse/NavEnhetInaktiv.tsx
+++ b/src/sider/01-personalia/adresse/NavEnhetInaktiv.tsx
@@ -13,12 +13,12 @@ export const NavEnhetInaktiv = () => {
 
     const {isMottakDeaktivert, isMottakMidlertidigDeaktivert} = adresser.navenhet;
 
-    const kommunenavn = adresser.navenhet.kommunenavn ?? "";
+    const enhetsnavn = adresser.navenhet.enhetsnavn ?? "";
 
     if (isMottakDeaktivert)
         return (
             <Alert variant="warning">
-                <BodyShort>{t("varig.melding", {kommunenavn})}</BodyShort>
+                <BodyShort>{t("varig.melding", {enhetsnavn})}</BodyShort>
                 {t.rich("varig.forslag", {
                     lenke: (chunks) => (
                         <Link href="https://www.nav.no/start/okonomisk-sosialhjelp" target="_blank">
@@ -32,7 +32,7 @@ export const NavEnhetInaktiv = () => {
     if (isMottakMidlertidigDeaktivert)
         return (
             <Alert variant="error">
-                <BodyShort>{t("midlertidig.melding", {kommunenavn})}</BodyShort>
+                <BodyShort>{t("midlertidig.melding", {enhetsnavn})}</BodyShort>
                 {t.rich("midlertidig.forslag", {
                     lenke: (chunks) => (
                         <Link href="https://www.nav.no/start/okonomisk-sosialhjelp" target="_blank">


### PR DESCRIPTION
Hvis vi uansett henviser brukeren til sitt Nav-kontor, hvorfor ikke navngi kontoret i denne feilmeldingen og ikke kommunen?